### PR TITLE
Changed java to jdk8

### DIFF
--- a/setup/ns-cli-setup/ns-setup-win.md
+++ b/setup/ns-cli-setup/ns-setup-win.md
@@ -42,7 +42,7 @@ On Windows systems, you can use the NativeScript CLI to develop only Android app
     1. In the command prompt, run the following command. 
         
         ```Shell
-        choco install java
+        choco install jdk8
         ```
     1. If not present, create the following environment variable.
 


### PR DESCRIPTION
From what I can see here:
https://chocolatey.org/packages?q=java

There is no such thing as a 'java' chocolatey package. I was given a "unable to find" error when running the original command.
