### PR TITLE
Replace Android Studio paths with brew sdk paths.

### DIFF
--- a/setup/ns-cli-setup/ns-setup-os-x.md
+++ b/setup/ns-cli-setup/ns-setup-os-x.md
@@ -80,7 +80,7 @@ On OS X systems, you can use the NativeScript CLI to develop Android and iOS app
             Path to the platform-tools subdirectory in the Android SDK installation directory
             ```
 
-            For example: Run the following command `export PATH=${PATH}:/Applications/Android Studio.app/sdk/tools:/Applications/Android Studio.app/sdk/platform-tools`
+            For example: Run the following command `export PATH="$PATH:/usr/local/Cellar/android-sdk/24/tools:/usr/local/Cellar/android-sdk/24/platform-tools"`
         1. Run the following command.
 
             ```


### PR DESCRIPTION
The previous step is to install android sdk with brew. Android Studio is not mentioned in this document at all.
