### PR TITLE
Removed mentions of nodejs-legacy

### DIFF
--- a/setup/ab-setup/ab-cli-setup.md
+++ b/setup/ab-setup/ab-cli-setup.md
@@ -204,9 +204,8 @@ With this IDE, you can develop for Android and iOS on Windows, OS X or Linux.
 1. Run the terminal.
 1. Install [Node.js](http://nodejs.org).
     
-    ```Shell
-    sudo apt-get install nodejs-legacy
-    ```
+    > **TIP:** You can follow the instructions provided [here](https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager) to install Node.js on your system.
+    
 1. If you are running on a 64-bit system, install the runtime libraries for the ia32/i386 architecture.
 
     ```Shell

--- a/setup/ns-cli-setup/ns-setup-linux.md
+++ b/setup/ns-cli-setup/ns-setup-linux.md
@@ -28,10 +28,9 @@ On Linux systems, you can use the NativeScript CLI to develop only Android apps.
 
 1. Run the terminal.
 1. Install [Node.js](http://nodejs.org).
+
+    > **TIP:** You can follow the instructions provided [here](https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager) to install Node.js on your system.
     
-    ```Shell
-    sudo apt-get install nodejs-legacy
-    ```
 1. If you are running on a 64-bit system, install the runtime libraries for the ia32/i386 architecture.
 
     ```Shell


### PR DESCRIPTION
Replaced them with links to official Node install documentation for Linux
