### PR TITLE
Added XML examples for CSS class and ID selectors

### DIFF
--- a/styling.md
+++ b/styling.md
@@ -133,6 +133,9 @@ label.cssClass = "title"
 var label = new labelModule.Label();
 label.cssClass = "title"
 ```
+```XML
+<Label cssClass="title" />
+```
 
 ### ID Selector
 [Id selectors](http://www.w3schools.com/cssref/sel_id.asp) select all views with a given id.
@@ -149,6 +152,9 @@ btn.id = "login-button"
 ```TypeScript
 var btn = new buttonModule.Button();
 btn.id = "login-button"
+```
+```XML
+<Button id="login-button" />
 ```
 
 ## Supported Properties


### PR DESCRIPTION
NativeScript does not use the HTML "class" attribute for setting CSS class names declaratively, so adding an XML example to make it clear "cssClass" should be used will improve the docs. Adding XML example for ID selector just to be thorough.
