### PR TITLE
Windows setup changes (Gradle and ANDROID_HOME)

### DIFF
--- a/setup/ns-cli-setup/ns-setup-win.md
+++ b/setup/ns-cli-setup/ns-setup-win.md
@@ -48,7 +48,7 @@ On Windows systems, you can use the NativeScript CLI to develop only Android app
         SETX JAVA_HOME "Path to the jdk* install folder" /M
         ```
 
-        For example: `SETX JAVA_HOME C:\Program Files\Java\jdk1.8.0_11 /M`
+        For example: `SETX JAVA_HOME "C:\Program Files\Java\jdk1.8.0_11" /M`
 1. Install [Gradle 2.3](https://docs.gradle.org/current/userguide/installation.html) or a later stable release.
     1. In the command prompt, run the following command.
 
@@ -82,7 +82,7 @@ On Windows systems, you can use the NativeScript CLI to develop only Android app
         SETX JAVA_HOME "Path to the Android SDK install folder" /M
         ```
 
-        For example: `SETX ANDROID_HOME C:\Program Files (x86)\Android\android-sdk /M`
+        For example: `SETX ANDROID_HOME "C:\Program Files (x86)\Android\android-sdk" /M`
     1. Restart the command prompt.
 1. Install the required Android SDKs and the Android Support Repository.
 

--- a/setup/ns-cli-setup/ns-setup-win.md
+++ b/setup/ns-cli-setup/ns-setup-win.md
@@ -49,14 +49,19 @@ On Windows systems, you can use the NativeScript CLI to develop only Android app
         ```
 
         For example: `SETX JAVA_HOME C:\Program Files\Java\jdk1.8.0_11 /M`
-1. Download and install [Gradle 2.3](https://docs.gradle.org/current/userguide/installation.html) or a later stable official release.
-1. If not present, add the following file path to the `PATH` system environment variable.
+1. Install [Gradle 2.2](https://docs.gradle.org/current/userguide/installation.html) or a later stable release.
+    1. In the command prompt, run the following command.
 
-	```
-	Path to the bin directory in the Gradle installation folder
-	```
+        ```Shell
+        choco install gradle
+        ```
+    1. If not present, add the following file path to the `PATH` system environment variable.
 
-	For example: `PATH=...;...;C:\tools\gradle-2.3\bin`
+        ```
+        Path to the bin directory in the Gradle installation folder
+        ```
+
+        For example: `PATH=...;...;C:\ProgramData\chocolatey\lib\gradle\tools\gradle-2.2.1\bin\`
 1. Install the [Android SDK](http://developer.android.com/sdk/index.html).
     1. In the command prompt, run the following command.
 
@@ -70,13 +75,13 @@ On Windows systems, you can use the NativeScript CLI to develop only Android app
         Path to platform-tools directory in the Android SDK installation folder
         ```
 
-        For example: `PATH=...;...;C:\Users\MyUser\AppData\Local\Android\android-sdk\tools;C:\Users\MyUser\AppData\Local\Android\android-sdk\platform-tools`
+        For example: `PATH=...;...;C:\Program Files (x86)\Android\android-sdk\tools;C:\Program Files (x86)\Android\android-sdk\platform-tools`
     1. Restart the command prompt.
 1. Install the required Android SDKs and the Android Support Repository.
 
-	```Shell
-	echo yes | android update sdk --filter tools,platform-tools,android-22,android-17,build-tools-22.0.1,sys-img-x86-android-22,extra-android-m2repository,extra-google-m2repository,extra-android-support --all --no-ui
-	```
+    ```Shell
+    echo yes | android update sdk --filter tools,platform-tools,android-22,android-17,build-tools-22.0.1,sys-img-x86-android-22,extra-android-m2repository,extra-google-m2repository,extra-android-support --all --no-ui
+    ```
 1. (Optional) Install Genymotion.<br/>Genymotion is a third-party native emulator.
     1. Go to [Get Genymotion](https://www.genymotion.com/#!/download), select Windows and click **Get Genymotion**.<br/>You might want to download the larger archive which contains VirtualBox.
     1. If prompted, confirm the download.

--- a/setup/ns-cli-setup/ns-setup-win.md
+++ b/setup/ns-cli-setup/ns-setup-win.md
@@ -21,7 +21,7 @@ On Windows systems, you can use the NativeScript CLI to develop only Android app
 * (Optional) Chocolatey to simplify the installation of dependencies
 * JDK 8 or a later stable official release
 * Android SDK 22 or a later stable official release
-* Gradle 2.2 or a later stable official release
+* Gradle 2.3 or a later stable official release
 * Android Support Repository
 * (Optional) Genymotion to expand your testing options
 
@@ -49,11 +49,11 @@ On Windows systems, you can use the NativeScript CLI to develop only Android app
         ```
 
         For example: `SETX JAVA_HOME C:\Program Files\Java\jdk1.8.0_11 /M`
-1. Install [Gradle 2.2](https://docs.gradle.org/current/userguide/installation.html) or a later stable release.
+1. Install [Gradle 2.3](https://docs.gradle.org/current/userguide/installation.html) or a later stable release.
     1. In the command prompt, run the following command.
 
         ```Shell
-        choco install gradle
+        choco install gradle -version 2.3
         ```
     1. If not present, add the following file path to the `PATH` system environment variable.
 
@@ -61,7 +61,7 @@ On Windows systems, you can use the NativeScript CLI to develop only Android app
         Path to the bin directory in the Gradle installation folder
         ```
 
-        For example: `PATH=...;...;C:\ProgramData\chocolatey\lib\gradle\tools\gradle-2.2.1\bin\`
+        For example: `PATH=...;...;C:\ProgramData\chocolatey\lib\gradle\tools\gradle-2.3\bin\`
 1. Install the [Android SDK](http://developer.android.com/sdk/index.html).
     1. In the command prompt, run the following command.
 

--- a/setup/ns-cli-setup/ns-setup-win.md
+++ b/setup/ns-cli-setup/ns-setup-win.md
@@ -21,7 +21,7 @@ On Windows systems, you can use the NativeScript CLI to develop only Android app
 * (Optional) Chocolatey to simplify the installation of dependencies
 * JDK 8 or a later stable official release
 * Android SDK 22 or a later stable official release
-* Gradle 2.3 or a later stable official release
+* Gradle 2.2 or a later stable official release
 * Android Support Repository
 * (Optional) Genymotion to expand your testing options
 
@@ -42,7 +42,7 @@ On Windows systems, you can use the NativeScript CLI to develop only Android app
         ```Shell
         choco install jdk8
         ```
-    1. If not present, create the following environment variable from a command-prompt, started as administrator.
+    1. If not present, create the following environment variable from a command-prompt, started as an administrator.
 
         ```
         SETX JAVA_HOME "Path to the jdk* install folder" /M
@@ -76,6 +76,13 @@ On Windows systems, you can use the NativeScript CLI to develop only Android app
         ```
 
         For example: `PATH=...;...;C:\Program Files (x86)\Android\android-sdk\tools;C:\Program Files (x86)\Android\android-sdk\platform-tools`
+    1. If not present, create the following environment variable from a command-prompt, started as an administrator.
+
+        ```
+        SETX JAVA_HOME "Path to the Android SDK install folder" /M
+        ```
+
+        For example: `SETX ANDROID_HOME C:\Program Files (x86)\Android\android-sdk /M`
     1. Restart the command prompt.
 1. Install the required Android SDKs and the Android Support Repository.
 


### PR DESCRIPTION
Ping @rosen-vladimirov @ligaz @ikoevska 

I created this PR to 1) add the `ANDROID_HOME` requirement, which seems to have been missing from this page, and 2) to switch the Gradle installation instructions to use `choco`.

For Gradle the `choco` installation is waaaay easier, and the [CLI's README](https://github.com/NativeScript/nativescript-cli/blob/master/README.md) already recommends `choco install gradle` (thus these two pages are out of sync). The one caveat is `choco install gradle` installs Gradle 2.2, and the current docs say 2.3+ is required. I just went through the installation on a fresh machine, and my Android builds are working with Gradle 2.2, but there's certainly a chance that I'm missing something. Let me know what you think.
