### PR TITLE
Getting started guide: master --> end

### DIFF
--- a/getting-started/chapter-1.md
+++ b/getting-started/chapter-1.md
@@ -54,11 +54,13 @@ After that, change to the newly cloned repo's folder:
 cd sample-Groceries
 ```
 
-The master branch has the final state of the Groceries app. Feel free to [refer back to it](https://github.com/NativeScript/sample-Groceries) at any time, but for now, switch over to the “start” branch for this guide's starting point:
+Finally, switch to the “start” branch for this guide's starting point:
 
 ```
 git checkout start
 ```
+
+>**TIP:** The “end” branch has the final state of this guide's tutorial. Feel free to [refer to the branch on GitHub](https://github.com/NativeScript/sample-Groceries/tree/end) if you get stuck.
 
 <div class="exercise-end"></div>
 

--- a/getting-started/chapter-4.md
+++ b/getting-started/chapter-4.md
@@ -124,7 +124,7 @@ exports.signIn = function() {
 };
 ```
 
-> **TIP**: You can always view the completed codebase in the 'master' branch of the [sample-Groceries repo](https://github.com/NativeScript/sample-Groceries.git).
+> **TIP**: You can always view the completed codebase in the “end” branch of the [sample-Groceries repo](https://github.com/NativeScript/sample-Groceries/tree/end).
 
 <div class="exercise-end"></div>
 

--- a/getting-started/chapter-6.md
+++ b/getting-started/chapter-6.md
@@ -188,4 +188,4 @@ Congratulations!
 
 > **TIP**:
 > * If you're curious about how NativeScript makes it possible to directly invoke iOS and Android APIs, you can read about [“How NativeScript Works”](http://developer.telerik.com/featured/nativescript-works/) on our blog.
-> * Remember that the [Groceries app's master branch](https://github.com/NativeScript/sample-Groceries) has the final state of this tutorial. Feel free to refer back to it at any time.
+> * Remember that the [Groceries app's “end” branch](https://github.com/NativeScript/sample-Groceries/tree/end) has the final state of this tutorial. Feel free to refer back to it at any time.


### PR DESCRIPTION
This PR changes the getting started guide to say that the completed code of the guide lives in Groceries' “end” branch rather than “master”, as we need the ability to evolve master without screwing up the state of this tutorial.

This is a small change but I could use a quick review of the wording. Ping @jlooper @ikoevska 
