### PR TITLE
navigation and styling articles

### DIFF
--- a/navigation.md
+++ b/navigation.md
@@ -270,7 +270,7 @@ topmost.goBack();
 
 Use the **showModal** method of the page class to show another page as a modal dialog. You must specify the location of the modal page module. You can provide a context and a callback function which will be called when the modal page is closed. You can also optionally specify whether to show the modal page in fullscreen or no. To close the modal page you need to subscribe to its `shownModally` event and store a reference to a close callback function provided through the event arguments. Call this function when you are ready to close the modal page optionally passing some results to the master page. Here is an example with two pages -- a main page and a login page. The main page shows the login page modally, the user enters his username and password and when ready clicks the Login button. This closes the modal login page and returns the username/password to the main page which can then log the user in.
 
-> **TIP:**By design in iOS, it is not possible to show a modal page in fullscreen.
+> **TIP:**By design in iOS, a modal page appears only in fullscreen.
 
 **main-page**
 ``` JavaScript

--- a/navigation.md
+++ b/navigation.md
@@ -270,6 +270,8 @@ topmost.goBack();
 
 Use the **showModal** method of the page class to show another page as a modal dialog. You must specify the location of the modal page module. You can provide a context and a callback function which will be called when the modal page is closed. You can also optionally specify whether to show the modal page in fullscreen or no. To close the modal page you need to subscribe to its `shownModally` event and store a reference to a close callback function provided through the event arguments. Call this function when you are ready to close the modal page optionally passing some results to the master page. Here is an example with two pages -- a main page and a login page. The main page shows the login page modally, the user enters his username and password and when ready clicks the Login button. This closes the modal login page and returns the username/password to the main page which can then log the user in.
 
+> **TIP:**By design in iOS, it is not possible to show a modal page in fullscreen.
+
 **main-page**
 ``` JavaScript
  var modalPageModule = "./modal-views-demo/login-page";

--- a/styling.md
+++ b/styling.md
@@ -29,7 +29,7 @@ The CSS styles can be set on 3 different levels:
 * [PageSpecific CSS](#page-specific-css)&mdash;applies to the page's UI views
 * [Inline CSS](#inline-css)&mdash;applies directly to a UI view
 
-Regardless of what level you apply the CSS on, it is parsed, its selectors are evaluated, and its properties are applied to the `style` object of each selected view. If there are selectors with one and the same name on different levels of applying css, the specified requirements will merge. For example, if a selector class with name "title" in an application-wide css file sets the font size of a text and a selector with the same name in a page-specific css file sets the text color, both requirements will be applied to the objects with class "title".
+If there is CSS declared on different levels - all will be applied. The inline CSS will have the highest priority and the allication CSS - the lowest.
 
 ### Application-Wide CSS
 

--- a/styling.md
+++ b/styling.md
@@ -29,7 +29,7 @@ The CSS styles can be set on 3 different levels:
 * [PageSpecific CSS](#page-specific-css)&mdash;applies to the page's UI views
 * [Inline CSS](#inline-css)&mdash;applies directly to a UI view
 
-Regardless of what level you apply the CSS on, it is parsed, its selectors are evaluated, and its properties are applied to the `style` object of each selected view.
+Regardless of what level you apply the CSS on, it is parsed, its selectors are evaluated, and its properties are applied to the `style` object of each selected view. If there are selectors with one and the same name on different levels of applying css, the specified requirements will merge. For example, if a selector class with name "title" in an application-wide css file sets the font size of a text and a selector with the same name in a page-specific css file sets the text color, both requirements will be applied to the objects with class "title".
 
 ### Application-Wide CSS
 


### PR DESCRIPTION
1. Navigation article - A tip added for modal pages not showing in full screen in iOS.
2. Styllingarticle - css selectors with the same name will be merged.
