### PR TITLE
iOS plugins fix

### DIFF
--- a/plugins.md
+++ b/plugins.md
@@ -109,7 +109,7 @@ my-plugin/
 
 * `platforms\android`: This directory contains any native Android libraries packaged as `*.jar` and `*.aar` packages. These native libraries can reside in the root of this directory or in a user-created sub-directory. During the plugin installation, the NativeScript CLI will configure the Android project in `platforms\android` to work with the plugin. 
 * `platforms\android\res`:  (Optional) This directory contains resources declared by the `AndroidManifest.xml` file. You can look at the folder structure [here](http://developer.android.com/guide/topics/resources/providing-resources.html#ResourceTypes).
-* `platforms\ios`: This directory contains native iOS dynamic libraries (`.framework`). During the plugin installation, the NativeScript CLI will copy these files to `lib\iOS` in your project and will configure the Android project in `platforms\ios` to work with the library.
+* `platforms\ios`: This directory contains native iOS frameworks (both static and shared). During the plugin installation, the NativeScript CLI will copy these files to `lib\iOS` in your project and will configure the iOS project in `platforms\ios` to work with the frameworks.
 * `platforms\android\include.gradle`: This file modifies the native Android configuration of your NativeScript project such as native dependencies, build types and configurations. For more information about the format of `include.gradle`, see [include.gradle file](#includegradle-specification).
 
 ### Package.json Specification


### PR DESCRIPTION
- Makes it clear that `platforms/ios` folder should not contains ordinary libraries (e.g. `.dylib` files) but only frameworks (`.framework`) and also the frameworks can be both static and shared.
- Fix a typo.
