### PR TITLE
Documentation for publishing apps to App Store and Google Play

### DIFF
--- a/core-concepts/releasing-apps.md
+++ b/core-concepts/releasing-apps.md
@@ -21,3 +21,15 @@ Publishing NativeScript apps in the App Store is similar to [releasing pure nati
 
 # Publishing in Google Play
 
+ 1. Verify that the Android native project inside your app contains your latest changes and resources by running the following command.
+ 
+     ```
+     tns prepare android
+     ```
+ 3. Make sure you have a .keystore file to sign your app with. [How to create  a .keystore file?](http://developer.android.com/tools/publishing/app-signing.html#signing-manually)
+ 2. Build your project in release mode by running the command:
+ 
+    ```
+    tns build android --release --key-store-path [path_to_your_keystore] --key-store-password [your_key_store_password] --key-store-alias [your_alias_name] --key-store-alias-password [your_alias_password] 
+    ```
+ 3. Find the release .apk file inside: `<app_name>/platforms/android/build/outputs/apk/<app_name>-release.apk` and upload it to Google Developer Console. [How to publish an android app?](http://developer.android.com/distribute/googleplay/start.html)

--- a/core-concepts/releasing-apps.md
+++ b/core-concepts/releasing-apps.md
@@ -26,10 +26,12 @@ Publishing NativeScript apps in the App Store is similar to [releasing pure nati
      ```
      tns prepare android
      ```
- 3. Make sure you have a .keystore file to sign your app with. [How to create  a .keystore file?](http://developer.android.com/tools/publishing/app-signing.html#signing-manually)
- 2. Build your project in release mode by running the command:
+ 2. Make sure that you have a `.keystore` file to sign your app with. For more information, see [How to create  a .keystore file?](http://developer.android.com/tools/publishing/app-signing.html#signing-manually)
+ 3. Build your project in release mode by running the following command:
  
     ```
     tns build android --release --key-store-path [path_to_your_keystore] --key-store-password [your_key_store_password] --key-store-alias [your_alias_name] --key-store-alias-password [your_alias_password] 
     ```
- 3. Find the release .apk file inside: `<app_name>/platforms/android/build/outputs/apk/<app_name>-release.apk` and upload it to Google Developer Console. [How to publish an android app?](http://developer.android.com/distribute/googleplay/start.html)
+ 4. Obtain the release `.apk` located at `<app_name>/platforms/android/build/outputs/apk/<app_name>-release.apk`.
+ 5. Publish your Android app by uploading the `.apk` file to the Google Developer Console. For more information, see [How to publish an android app?](http://developer.android.com/distribute/googleplay/start.html)
+ 

--- a/core-concepts/releasing-apps.md
+++ b/core-concepts/releasing-apps.md
@@ -1,23 +1,23 @@
 ---
-title: Releasing NativeScript Applications to the App Store and Google Play Store
-description: Learn how to release NativeScript applications to the App Store and Google Play Store
+title: Publishing NativeScript Apps in the App Store and Google Play
+description: Learn how to make your NativeScript apps available to end users by publishing them in the App Store and Google Play.
 position: 10
 slug: releasing-apps
 ---
 
-# Releasing to App Store
+# Publishing in the App Store
 
-The process of releasing NativeScript app to App Store is not much different than [releasing pure native iOS application](https://developer.apple.com/library/ios/documentation/IDEs/Conceptual/AppDistributionGuide/Introduction/Introduction.html). After making sure the NativeScript app is prepared by running
+Publishing NativeScript apps in the App Store is similar to [releasing pure native iOS apps](https://developer.apple.com/library/ios/documentation/IDEs/Conceptual/AppDistributionGuide/Introduction/Introduction.html).
 
-```
-tns prepare ios
-```
+ 1. Verify that the iOS native project inside your app contains your latest changes and resources by running the following command.
+ 
+     ```
+     tns prepare ios
+     ```
+ 2. Open the iOS native project in Xcode. Your native project is located at: `{app-name}/platforms/ios/{app-name}.xcodeproj`.
+ 3. [Configure the project for distribution](https://developer.apple.com/library/ios/documentation/IDEs/Conceptual/AppDistributionGuide/ConfiguringYourApp/ConfiguringYourApp.html).
+ 4. [Upload the app to iTunes Connect](https://developer.apple.com/library/ios/documentation/IDEs/Conceptual/AppDistributionGuide/UploadingYourApptoiTunesConnect/UploadingYourApptoiTunesConnect.html).
+ 5. [Submit it to App Store](https://developer.apple.com/library/ios/documentation/LanguagesUtilities/Conceptual/iTunesConnect_Guide/Chapters/SubmittingTheApp.html).
 
-open the underlying project at `{app-name}/platforms/ios/{app-name}.xcodeproj` in Xcode.
-
-> The underlying Xcode project is created and maintained by the NativeScript CLI. Under the hood, many CLI commands apply modifications to the project making them transparent to the NativeScript developer.
-
-From here, you have to [configure your Xcode project for distribution](https://developer.apple.com/library/ios/documentation/IDEs/Conceptual/AppDistributionGuide/ConfiguringYourApp/ConfiguringYourApp.html), [upload it to iTunes Connect](https://developer.apple.com/library/ios/documentation/IDEs/Conceptual/AppDistributionGuide/UploadingYourApptoiTunesConnect/UploadingYourApptoiTunesConnect.html) and [submit it to App Store](https://developer.apple.com/library/ios/documentation/LanguagesUtilities/Conceptual/iTunesConnect_Guide/Chapters/SubmittingTheApp.html). The whole process is explained in details in Apple's [App Distribution Guide](https://developer.apple.com/library/ios/documentation/IDEs/Conceptual/AppDistributionGuide/Introduction/Introduction.html).
-
-# Releasing to Google Play Store
+# Publishing in Google Play
 

--- a/core-concepts/releasing-apps.md
+++ b/core-concepts/releasing-apps.md
@@ -1,0 +1,23 @@
+---
+title: Releasing NativeScript Applications to the App Store and Google Play Store
+description: Learn how to release NativeScript applications to the App Store and Google Play Store
+position: 10
+slug: releasing-apps
+---
+
+# Releasing to App Store
+
+The process of releasing NativeScript app to App Store is not much different than [releasing pure native iOS application](https://developer.apple.com/library/ios/documentation/IDEs/Conceptual/AppDistributionGuide/Introduction/Introduction.html). After making sure the NativeScript app is prepared by running
+
+```
+tns prepare ios
+```
+
+open the underlying project at `{app-name}/platforms/ios/{app-name}.xcodeproj` in Xcode.
+
+> The underlying Xcode project is created and maintained by the NativeScript CLI. Under the hood, many CLI commands apply modifications to the project making them transparent to the NativeScript developer.
+
+From here, you have to [configure your Xcode project for distribution](https://developer.apple.com/library/ios/documentation/IDEs/Conceptual/AppDistributionGuide/ConfiguringYourApp/ConfiguringYourApp.html), [upload it to iTunes Connect](https://developer.apple.com/library/ios/documentation/IDEs/Conceptual/AppDistributionGuide/UploadingYourApptoiTunesConnect/UploadingYourApptoiTunesConnect.html) and [submit it to App Store](https://developer.apple.com/library/ios/documentation/LanguagesUtilities/Conceptual/iTunesConnect_Guide/Chapters/SubmittingTheApp.html). The whole process is explained in details in Apple's [App Distribution Guide](https://developer.apple.com/library/ios/documentation/IDEs/Conceptual/AppDistributionGuide/Introduction/Introduction.html).
+
+# Releasing to Google Play Store
+

--- a/core-concepts/releasing-apps.md
+++ b/core-concepts/releasing-apps.md
@@ -17,7 +17,7 @@ Publishing NativeScript apps in the App Store is similar to [releasing pure nati
  2. Open the iOS native project in Xcode. Your native project is located at: `{app-name}/platforms/ios/{app-name}.xcodeproj`.
  3. [Configure the project for distribution](https://developer.apple.com/library/ios/documentation/IDEs/Conceptual/AppDistributionGuide/ConfiguringYourApp/ConfiguringYourApp.html).
  4. [Upload the app to iTunes Connect](https://developer.apple.com/library/ios/documentation/IDEs/Conceptual/AppDistributionGuide/UploadingYourApptoiTunesConnect/UploadingYourApptoiTunesConnect.html).
- 5. [Submit it to App Store](https://developer.apple.com/library/ios/documentation/LanguagesUtilities/Conceptual/iTunesConnect_Guide/Chapters/SubmittingTheApp.html).
+ 5. [Submit it to the App Store](https://developer.apple.com/library/ios/documentation/LanguagesUtilities/Conceptual/iTunesConnect_Guide/Chapters/SubmittingTheApp.html).
 
 # Publishing in Google Play
 
@@ -33,5 +33,5 @@ Publishing NativeScript apps in the App Store is similar to [releasing pure nati
     tns build android --release --key-store-path [path_to_your_keystore] --key-store-password [your_key_store_password] --key-store-alias [your_alias_name] --key-store-alias-password [your_alias_password] 
     ```
  4. Obtain the release `.apk` located at `<app_name>/platforms/android/build/outputs/apk/<app_name>-release.apk`.
- 5. Publish your Android app by uploading the `.apk` file to the Google Developer Console. For more information, see [How to publish an android app?](http://developer.android.com/distribute/googleplay/start.html)
+ 5. Publish your Android app by uploading the `.apk` file to the Google Developer Console. For more information, see [How to publish an Android app?](http://developer.android.com/distribute/googleplay/start.html)
  


### PR DESCRIPTION
Not ready yet. Publishing to Google Play Store should be added.

NativeScript/ios-runtime#427
