### PR TITLE
Users attempting to load plugins that have cocoapod dependancies will fail

### DIFF
--- a/core-concepts/testing.md
+++ b/core-concepts/testing.md
@@ -3,6 +3,7 @@ title: Unit Testing
 description: Learn how to write and execute tests for your NativeScript app.
 position: 7
 slug: unit-testing
+previous_url: /testing
 ---
 
 # Unit Testing

--- a/core-concepts/transpilers.md
+++ b/core-concepts/transpilers.md
@@ -3,6 +3,7 @@ title: Transpilers
 description: Learn how to enable TypeScript and other transpiler support in your project.
 position: 8
 slug: transpilers
+previous_url: /transpilers
 ---
 
 # Using transpilers in NativeScript

--- a/core-concepts/transpilers.md
+++ b/core-concepts/transpilers.md
@@ -37,6 +37,46 @@ If you want to change the version of the Babel compiler used in your project, si
 
 If you want to configure Babel, create a `.babelrc` file in the root of your project according to [spec](https://babeljs.io/docs/usage/babelrc/).
 
+## Installing XML validation against XSD schema
+
+Run the following command to install XML validation against XSD schema into your project:
+
+```Shell
+tns install xmlxsd
+```
+
+The above command installs the `nativescript-dev-xmlxsd` npm module as a dev dependencies. The latter installs a `prepare` hook into your project, that validates your XML files against NativeScript XSD schema during build and when live-syncing.
+
+If you want to change the version of the XML validation against XSD schema used in your project, simply install the version you want into your project through npm.
+
+## Installing Less CSS pre-processor
+
+Run the following command to install Less CSS pre-processor into your project:
+
+```Shell
+tns install less
+```
+
+The above command installs the `nativescript-dev-less` npm module as a dev dependencies. The latter installs a `prepare` hook into your project, that converts your *.less files to *.css files during build and when live-syncing.
+
+If you want to change the version of the Less CSS pre-processor used in your project, simply install the version you want into your project through npm.
+
+For more info about Less CSS pre-processor please visit http://lesscss.org/.
+
+## Installing Jade
+
+Run the following command to install Jade language support into your project:
+
+```Shell
+tns install jade
+```
+
+The above command installs the `nativescript-dev-jade` npm module as a dev dependencies. The latter installs a `prepare` hook into your project, that converts your *.jade files to *.xml files during build and when live-syncing.
+
+If you want to change the version of the Jade language support used in your project, simply install the version you want into your project through npm.
+
+For more info about Jade language please visit http://jade-lang.com/.
+
 ## Installing other transpilers
 
 Transpiler support can be extended through the use of hooks. The easiest way to distribute transpiler hooks is by means of npm modules. You can use the implementation of the TypeScript and Babel hooks as reference and grok the [nativescript-hook module](https://github.com/NativeScript/nativescript-hook) that provides common hook installation support to transpiler authors.

--- a/plugins/plugins.md
+++ b/plugins/plugins.md
@@ -91,7 +91,7 @@ my-plugin/
 * `platforms\android\include.gradle`: This file modifies the native Android configuration of your NativeScript project such as native dependencies, build types and configurations. For more information about the format of `include.gradle`, see [include.gradle file](#includegradle-specification).
 * `platforms/android/res`:  (Optional) This directory contains resources declared by the `AndroidManifest.xml` file. You can look at the folder structure [here](http://developer.android.com/guide/topics/resources/providing-resources.html#ResourceTypes).
 * `platforms/ios/Info.plist`: This file describes any specific configuration changes required for your plugin to work. For example: required permissions. For more information about the format of `Info.plist`, see [About Information Property List Files](https://developer.apple.com/library/ios/documentation/General/Reference/InfoPlistKeyReference/Articles/AboutInformationPropertyListFiles.html).<br/>During the plugin installation, the NativeScript CLI will merge the plugin `Info.plist` with the `Info.plist` for your project. The NativeScript CLI will not resolve any contradicting or duplicate entries during the merge. After the plugin is installed, you need to manually resolve such issues.
-* `platforms/ios/Podfile`: This file describes the dependency to the library that you want to use. For more information, see [CocoaPods.md](CocoaPods.md).
+* `platforms/ios/Podfile`: This file describes the dependency to the library that you want to use. For more information, see [the CocoaPods article](CocoaPods.md).
 
 NativeScript plugins which contain both native Android and iOS libraries might have the following directory structure.
 

--- a/releases/Android Runtime.md
+++ b/releases/Android Runtime.md
@@ -7,6 +7,23 @@ slug: android-changelog
 previous_url: /Changelogs/Android Runtime
 ---
 
+1.5.1
+==
+
+## What's New
+
+ - [Enable requiring of JSON files (like in Node) (#217)](https://github.com/NativeScript/android-runtime/issues/217)
+ - [Revisit the "assert" routine in the JNI part (#221)](https://github.com/NativeScript/android-runtime/issues/221)
+ - [Android CallStack  (#228)](https://github.com/NativeScript/android-runtime/issues/228)
+ - [error handling introducing c++ exceptions (#277)](https://github.com/NativeScript/android-runtime/pull/277)
+ - [Simplify require errors (#287)](https://github.com/NativeScript/android-runtime/issues/287)
+ - [Experimental: Support native modules (#291)](https://github.com/NativeScript/android-runtime/issues/291)
+ - Gradle script improvements
+
+## Bug Fixes
+
+ - [Print meaningful error when metadata generator fails to reflect a class (#245)](https://github.com/NativeScript/android-runtime/issues/245)
+
 1.5.0
 ==
 

--- a/releases/CLI.md
+++ b/releases/CLI.md
@@ -10,6 +10,17 @@ previous_url: /Changelogs/CLI
 NativeScript CLI Changelog
 ================
 
+1.5.2 (2015, December 12)
+==
+### New
+* [Implemented #1247](https://github.com/NativeScript/nativescript-cli/issues/1247): Do not kill adb server if possible.
+
+### Fixed
+* [Fixed #956](https://github.com/NativeScript/nativescript-cli/issues/956): Better error reporting for deploy on device.
+* [Fixed #1210](https://github.com/NativeScript/nativescript-cli/issues/1210): LiveSync does not handle correctly removed files on iOS simulator.
+* [Fixes #1308](https://github.com/NativeScript/nativescript-cli/issues/1308): Livesync ends up with an endless loop for projects that have before-prepare hook that changes some project file.
+* [Fixed #1313](https://github.com/NativeScript/nativescript-cli/issues/1313): `tns livesync ios --watch --emulator` command does not process platform specific files.
+
 1.5.1 (2015, December 03)
 ==
 ### New

--- a/releases/iOS Runtime.md
+++ b/releases/iOS Runtime.md
@@ -7,6 +7,19 @@ slug: ios-changelog
 previous_url: /Changelogs/iOS Runtime
 ---
 
+1.5.1
+=====
+
+## Bug Fixes
+- [Loading static frameworks as shared frameworks](https://github.com/NativeScript/ios-runtime/issues/373)
+- [Marshaling boxed JavaScript primitive types throws an exception](https://github.com/NativeScript/ios-runtime/issues/411)
+
+## What's New
+
+- [Simplify require errors.](https://github.com/NativeScript/ios-runtime/pull/424)
+- [Update JavaScriptCore](https://github.com/NativeScript/ios-runtime/issues/355)
+- [Enable requiring of JSON files](https://github.com/NativeScript/ios-runtime/issues/294)
+
 1.5.0
 =====
 

--- a/start/ns-setup-os-x.md
+++ b/start/ns-setup-os-x.md
@@ -51,6 +51,14 @@ For Android development
     ```Shell
     brew install homebrew/versions/node012
     ```
+1. Install and configure cocoapods 
+
+    ```Shell
+    sudo gem install cocoapods
+    ```
+    ```Shell
+    pod setup
+    ```
 1. Install the dependencies for iOS development.
     1. Run the App Store and download and install Xcode 5 or later.
     1. Go to [Downloads for Apple Developers](https://developer.apple.com/downloads/index.action), log in and download and install the **Command Line Tools for Xcode** for your version of OS X and Xcode.

--- a/ui/ui-with-xml.md
+++ b/ui/ui-with-xml.md
@@ -760,7 +760,7 @@ Since NativeScript 1.3 you can declare your UI using lower-case-dashed syntax:
 <page>
   <scroll-view>
     <stack-layout>
-      <label ctext="Label" />
+      <label text="Label" />
       <button text="Button" tap="tap" />
       ...
 ```


### PR DESCRIPTION
This setup instruction will help users who are trying to load plugins that require cocoapods.

There's already a bunch of posts out there related to the strange error

```
Creating shallow clone of spec repo `master` from `https://github.com/CocoaPods/Specs.git`
[!] Unable to add a source with url `https://github.com/CocoaPods/Specs.git` named `master`.
You can try adding it manually in `~/.cocoapods/repos` or via `pod repo add`.
Processing node_modules failed. Error:Error: Command sandbox-pod failed with exit code 1
```

https://groups.google.com/forum/#!msg/nativescript/BFayGzYA1xM/WPFmhxbxBgAJ
