### PR TITLE
fixed bug that broke navigation after login failed.

### DIFF
--- a/start/getting-started/chapter-4.md
+++ b/start/getting-started/chapter-4.md
@@ -155,16 +155,16 @@ Next, re-write your `signIn()` function to look like this:
 ``` JavaScript
 exports.signIn = function() {
     user.login()
+        .then(function() {
+            frameModule.topmost().navigate("views/list/list");
+        })
         .catch(function(error) {
             console.log(error);
             dialogsModule.alert({
                 message: "Unfortunately we could not find your account.",
                 okButtonText: "OK"
             });
-        })
-        .then(function() {
-            frameModule.topmost().navigate("views/list/list");
-        });
+        });        
 };
 ```
 <div class="exercise-end"></div>


### PR DESCRIPTION
Hi,

I was trying out the "Getting Started" guide when I encountered a small bug in part 4.1. This pull request fixes it.

The steps to reproduce are : 
- paste the code snippet described in part 4.1 in the project (after following all the previous steps, obviously)
- launch the app
- enter account credentials that don't exist 
- the error popup appears.
- then enter credentials that do exists
- => nothing happens when I expected to navigate to another page.

I reproduced this error on the ios simulator 8.4. The console also logged the following output :
`sampleGroceries[21575]: pushViewController:animated: called on <UINavigationControllerImpl 0x7b967a60> while an existing transition or presentation is occurring; the navigation stack will not be updated.
`

That's it. Thank you for a great guide so far !
