### PR TITLE
Update Android Build Tools requirement

### DIFF
--- a/start/ns-setup-linux.md
+++ b/start/ns-setup-linux.md
@@ -25,7 +25,7 @@ On Linux systems, you can use the NativeScript CLI to develop only Android apps.
 * JDK 8 or a later stable official release
 * Android SDK 22 or a later stable official release
 * Android Support Repository
-* Android SDK Build-tools 22.0.0 or a later stable official release
+* Android SDK Build-tools 23.0.0 or a later stable official release
 * (Optional) Genymotion to expand your testing options
 
 ## Environment Requirements
@@ -36,7 +36,7 @@ On Linux systems, you can use the NativeScript CLI to develop only Android apps.
 ## Setup
 
 1. Run the terminal.
-1. Install the latest Node.js [0.10.x](https://nodejs.org/dist/latest-v0.10.x/), [0.12.x](https://nodejs.org/dist/latest-v0.12.x/), or [4.2.x](https://nodejs.org/dist/latest-v4.x/) stable official release.
+1. Install the latest Node.js [0.10.x](https://nodejs.org/dist/latest-v0.10.x/), [0.12.x](https://nodejs.org/dist/latest-v0.12.x/), or [4.x](https://nodejs.org/dist/latest-v4.x/) stable official release.
 1. If you are running on a 64-bit system, install the runtime libraries for the ia32/i386 architecture.
 
     ```Shell
@@ -81,7 +81,7 @@ On Linux systems, you can use the NativeScript CLI to develop only Android apps.
 1. Install the required Android SDKs and the Android Support Repository.
 
 	```Shell
-	sudo $ANDROID_HOME/tools/android update sdk --filter tools,platform-tools,android-22,build-tools-22.0.1,extra-android-m2repository,extra-google-m2repository,extra-android-support --all --no-ui
+	sudo $ANDROID_HOME/tools/android update sdk --filter tools,platform-tools,android-22,build-tools-23.0.2,extra-android-m2repository,extra-google-m2repository,extra-android-support --all --no-ui
 	```
 1. (Optional) Install Genymotion.<br/>Genymotion is a third-party native emulator.
     1. Go to [Download VirtualBox](https://www.virtualbox.org/wiki/Downloads) and download and install VirtualBox for Linux.

--- a/start/ns-setup-os-x.md
+++ b/start/ns-setup-os-x.md
@@ -29,12 +29,12 @@ On OS X systems, you can use the NativeScript CLI to develop Android and iOS app
     * JDK 8 or a later stable official release
     * Android SDK 22 or a later stable official release
     * Android Support Repository
-    * Android SDK Build-tools 22.0.0 or a later stable official release
+    * Android SDK Build-tools 23.0.0 or a later stable official release
     * (Optional) Genymotion to expand your testing options
 
 ### Quick setup
 
-If this is your first time developing a mobile project, consider using the one-liner scripts in this section to effortlessly setup your machine. 
+If this is your first time developing a mobile project, consider using the one-liner scripts in this section to effortlessly setup your machine.
 If you have experience developing mobile apps, you may skip to the [Environment Requirements](#environment-requirements) section below.
 
 Using Spotlight, search `Terminal` and start it. This opens a console window. Copy and paste this script:
@@ -49,7 +49,7 @@ For Android development
 
 * JAVA_HOME environment variable must be set
 * ANDROID_HOME environment variable must be set
-    
+
 ## Setup
 
 1. Install [Homebrew](http://brew.sh) to simplify the installation process.
@@ -86,10 +86,10 @@ For Android development
             ```
             For example: ANDROID_HOME=/usr/local/Cellar/android-sdk/24/
             > NOTE: This is the directory that contains `tools` and `platform-tools` directories.
-        1. Select all packages for the Android 22 SDK, Android SDK Build-tools 22.0.0 or later, Android Support Repository (under Extras) and any other SDKs that you want to install and click **Install**.
+        1. Select all packages for the Android 22 SDK, Android SDK Build-tools 23.0.0 or later, Android Support Repository (under Extras) and any other SDKs that you want to install and click **Install**.
            You can use the following command, that will install all required tools:
            ```
-           android update sdk --filter tools,platform-tools,android-22,build-tools-22.0.1,extra-android-m2repository,extra-google-m2repository,extra-android-support --all --no-ui
+           android update sdk --filter tools,platform-tools,android-22,build-tools-23.0.2,extra-android-m2repository,extra-google-m2repository,extra-android-support --all --no-ui
            ```
     1. (Optional) Install Genymotion.<br/>Genymotion is a third-party native emulator.
         1. Go to [Download VirtualBox](https://www.virtualbox.org/wiki/Downloads) and download and install VirtualBox for OS X.

--- a/start/ns-setup-win.md
+++ b/start/ns-setup-win.md
@@ -25,19 +25,19 @@ On Windows systems, you can use the NativeScript CLI to develop only Android app
 * JDK 8 or a later stable official release
 * Android SDK 22 or a later stable official release
 * Android Support Repository
-* Android SDK Build-tools 22.0.0 or a later stable official release
+* Android SDK Build-tools 23.0.0 or a later stable official release
 * (Optional) Genymotion to expand your testing options
 
 ### Quick setup
 
-If this is your first time developing a mobile project, consider using the one-liner scripts in this section to effortlessly setup your machine. 
+If this is your first time developing a mobile project, consider using the one-liner scripts in this section to effortlessly setup your machine.
 If you have experience developing mobile apps, you may skip to the [Environment Requirements](#environment-requirements) section below.
 
 Open Start Menu, search for `Command Prompt` and start it. This opens a console window. Copy and paste this script:
 
 > @powershell -NoProfile -ExecutionPolicy Bypass -Command "iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/NativeScript/nativescript-cli/production/setup/native-script.ps1'))"
 
-You may need to accept an User Account Control prompt to grant the script administrative privileges. Note that the script downloads and installs some big dependencies and may take some time to complete. 
+You may need to accept an User Account Control prompt to grant the script administrative privileges. Note that the script downloads and installs some big dependencies and may take some time to complete.
 
 ## Environment Requirements
 
@@ -87,7 +87,7 @@ For Android development
 1. Install the required Android SDKs and the Android Support Repository.
 
 	```Shell
-	echo yes | "%ANDROID_HOME%\tools\android" update sdk --filter tools,platform-tools,android-22,build-tools-22.0.1,extra-android-m2repository,extra-google-m2repository,extra-android-support --all --no-ui
+	echo yes | "%ANDROID_HOME%\tools\android" update sdk --filter tools,platform-tools,android-22,build-tools-23.0.2,extra-android-m2repository,extra-google-m2repository,extra-android-support --all --no-ui
 	```
 1. (Optional) Install Genymotion.<br/>Genymotion is a third-party native emulator.
     1. Go to [Get Genymotion](https://www.genymotion.com/#!/download), select Windows and click **Get Genymotion**.<br/>You might want to download the larger archive which contains VirtualBox.


### PR DESCRIPTION
Update Android Build Tools requirement to be at least 23.0.0
