### PR TITLE
Remove duplicate closing tag & spacing

### DIFF
--- a/ApiReference/ui/layouts/dock-layout/HOW-TO.md
+++ b/ApiReference/ui/layouts/dock-layout/HOW-TO.md
@@ -11,13 +11,13 @@ var dockModule = require("ui/layouts/dock-layout");
 ### Declaring a DockLayout.
 ``` XML
 <Page>
- <DockLayout stretchLastChild="true" >
-   <Button dock="left" text="left" style="background-color: red; margin: 5;"/ >/ >
-   <Button dock="top" text="top" style="background-color: lightblue; margin: 5;"/ >
-   <Button dock="right" text="right" style="background-color: lightgreen; margin: 5;"/ >
-   <Button dock="bottom" text="bottom" style="background-color: lightpink; margin: 5;"/ >
-   <Button text="fill" style="background-color: wheat; margin: 5;"/ >
- </DockLayout >
+ <DockLayout stretchLastChild="true">
+   <Button dock="left" text="left" style="background-color: red; margin: 5;" />
+   <Button dock="top" text="top" style="background-color: lightblue; margin: 5;" />
+   <Button dock="right" text="right" style="background-color: lightgreen; margin: 5;" />
+   <Button dock="bottom" text="bottom" style="background-color: lightpink; margin: 5;" />
+   <Button text="fill" style="background-color: wheat; margin: 5;" />
+ </DockLayout>
 </Page>
 ```
 ## Create DockLayout


### PR DESCRIPTION
Fixed duplicate closing tag on the first `<button>` and removed the single space between the closing tags.
