### PR TITLE
Shorten setup scripts links

### DIFF
--- a/start/ns-setup-os-x.md
+++ b/start/ns-setup-os-x.md
@@ -41,7 +41,7 @@ If you have experience developing mobile apps, you may skip to the [Environment 
 
 Using Spotlight, search `Terminal` and start it. This opens a console window. Copy and paste this script:
 
-> ruby -e "$(curl -fsSL https://raw.githubusercontent.com/NativeScript/nativescript-cli/production/setup/native-script.rb)"
+> ruby -e "$(curl -fsSL https://www.nativescript.org/setup/mac)"
 
 The script calls some of the commands using `sudo` and you may need to provide your password several times. Note that the script downloads and installs some big dependencies and may take some time to complete.
 

--- a/start/ns-setup-win.md
+++ b/start/ns-setup-win.md
@@ -35,7 +35,7 @@ If you have experience developing mobile apps, you may skip to the [Environment 
 
 Open Start Menu, search for `Command Prompt` and start it. This opens a console window. Copy and paste this script:
 
-> @powershell -NoProfile -ExecutionPolicy Bypass -Command "iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/NativeScript/nativescript-cli/production/setup/native-script.ps1'))"
+> @powershell -NoProfile -ExecutionPolicy Bypass -Command "iex ((new-object net.webclient).DownloadString('https://www.nativescript.org/setup/win'))"
 
 You may need to accept an User Account Control prompt to grant the script administrative privileges. Note that the script downloads and installs some big dependencies and may take some time to complete.
 

--- a/start/quick-setup.md
+++ b/start/quick-setup.md
@@ -43,7 +43,7 @@ If you have experience developing mobile apps, you may skip to the [advanced set
 
 Open Start Menu, search for `Command Prompt` and start it. This opens a console window. Copy and paste this script:
 
-> @powershell -NoProfile -ExecutionPolicy Bypass -Command "iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/NativeScript/nativescript-cli/production/setup/native-script.ps1'))"
+> @powershell -NoProfile -ExecutionPolicy Bypass -Command "iex ((new-object net.webclient).DownloadString('https://www.nativescript.org/setup/win'))"
 
 You may need to accept an User Account Control prompt to grant the script administrative privileges. Note that the script downloads and installs some big dependencies and may take some time to complete. 
 
@@ -51,7 +51,7 @@ You may need to accept an User Account Control prompt to grant the script admini
 
 Using Spotlight, search `Terminal` and start it. This opens a console window. Copy and paste this script:
 
-> ruby -e "$(curl -fsSL https://raw.githubusercontent.com/NativeScript/nativescript-cli/production/setup/native-script.rb)"
+> ruby -e "$(curl -fsSL https://www.nativescript.org/setup/mac)"
 
 The script calls some of the commands using `sudo` and you may need to provide your password several times. Note that the script downloads and installs some big dependencies and may take some time to complete.
 

--- a/tutorial/chapter-1.md
+++ b/tutorial/chapter-1.md
@@ -74,7 +74,7 @@ When you build with NativeScript you’re building truly native iOS and Android 
 If you’re on Windows, copy and paste the script below into your command prompt and press Enter:
 
 ```
-@powershell -NoProfile -ExecutionPolicy Bypass -Command "iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/NativeScript/nativescript-cli/production/setup/native-script.ps1'))"
+@powershell -NoProfile -ExecutionPolicy Bypass -Command "iex ((new-object net.webclient).DownloadString('https://www.nativescript.org/setup/win'))"
 ```
 
 During installation you may need to accept a User Account Control prompt to grant the script administrative privileges. Also, be aware that the script downloads and installs some big dependencies—so it’s common for the script to take a while to complete. When the script finishes, close and reopen your command prompt.
@@ -84,7 +84,7 @@ During installation you may need to accept a User Account Control prompt to gran
 If you’re on a Mac, copy and paste the script below into your terminal and press Enter:
 
 ```
-ruby -e "$(curl -fsSL https://raw.githubusercontent.com/NativeScript/nativescript-cli/production/setup/native-script.rb)"
+ruby -e "$(curl -fsSL https://www.nativescript.org/setup/mac)"
 ```
 
 Much like the Windows script, the OS X script needs administrative access to run some commands using `sudo`; therefore, you may need to provide your password several times during execution. The OS X script also may take some time to complete, as it’s installing the dependencies for both iOS and Android development. When the script finishes, close and restart your terminal.

--- a/tutorial/ng-chapter-1.md
+++ b/tutorial/ng-chapter-1.md
@@ -75,7 +75,7 @@ When you build with NativeScript you’re building truly native iOS and Android 
 If you’re on Windows, copy and paste the script below into your command prompt and press Enter:
 
 ```
-@powershell -NoProfile -ExecutionPolicy Bypass -Command "iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/NativeScript/nativescript-cli/production/setup/native-script.ps1'))"
+@powershell -NoProfile -ExecutionPolicy Bypass -Command "iex ((new-object net.webclient).DownloadString('https://www.nativescript.org/setup/win'))"
 ```
 
 During installation you may need to accept a User Account Control prompt to grant the script administrative privileges. Also, be aware that the script downloads and installs some big dependencies—so it’s common for the script to take a while to complete. When the script finishes, close and reopen your command prompt.
@@ -85,7 +85,7 @@ During installation you may need to accept a User Account Control prompt to gran
 If you’re on a Mac, copy and paste the script below into your terminal and press Enter:
 
 ```
-ruby -e "$(curl -fsSL https://raw.githubusercontent.com/NativeScript/nativescript-cli/production/setup/native-script.rb)"
+ruby -e "$(curl -fsSL https://www.nativescript.org/setup/mac)"
 ```
 
 Much like the Windows script, the OS X script needs administrative access to run some commands using `sudo`; therefore, you may need to provide your password several times during execution. The OS X script also may take some time to complete, as it’s installing the dependencies for both iOS and Android development. When the script finishes, close and restart your terminal.


### PR DESCRIPTION
Shorten:
- https://raw.githubusercontent.com/NativeScript/nativescript-cli/production/setup/native-script.rb to https://www.nativescript.org/setup/mac
- https://raw.githubusercontent.com/NativeScript/nativescript-cli/production/setup/native-script.ps1 to https://www.nativescript.org/setup/win

The shorthands actually redirect to the longer urls.
Ping @vchimev 
