### PR TITLE
Link to NS cookbook using the new {%ns_cookbook%} helper

### DIFF
--- a/core-concepts/modules.md
+++ b/core-concepts/modules.md
@@ -27,72 +27,72 @@ In your project, the files for each module reside in a dedicated subdirectory in
 * 
 ### Core modules
 
-+ [application](/cookbook/application): Provides the application abstraction with all related methods.
-+ [console](/cookbook/console): Lets you print messages to the device console.
-+ [application-settings](/cookbook/application-settings): Lets you save and restore any information related to your application.
-+ [http](/cookbook/http): Lets you send web requests and receive the responses.
-+ [image-source](/cookbook/image-source): Provides the `ImageSource` class which encapsulates the common abstraction behind a platform-specific object that is used as a source for images (typically a Bitmap).
-+ [timer](/cookbook/timer): Lets you to create, start, stop and react to timers.
-+ [trace](/cookbook/trace): Lets you trace and print specific information based on categories.
-+ [ui/image-cache](/cookbook/ui/image-cache): Provides the `Cache` class which handles image download requests and caches the already downloaded images.
-+ [connectivity](/cookbook/connectivity): Lets you check the type of Internet connection and monitor its state changes.
++ [application]({%ns_cookbook application%}): Provides the application abstraction with all related methods.
++ [console]({%ns_cookbook console%}): Lets you print messages to the device console.
++ [application-settings]({%ns_cookbook application-settings%}): Lets you save and restore any information related to your application.
++ [http]({%ns_cookbook http%}): Lets you send web requests and receive the responses.
++ [image-source]({%ns_cookbook image-source%}): Provides the `ImageSource` class which encapsulates the common abstraction behind a platform-specific object that is used as a source for images (typically a Bitmap).
++ [timer]({%ns_cookbook timer%}): Lets you to create, start, stop and react to timers.
++ [trace]({%ns_cookbook trace%}): Lets you trace and print specific information based on categories.
++ [ui/image-cache]({%ns_cookbook ui/image-cache%}): Provides the `Cache` class which handles image download requests and caches the already downloaded images.
++ [connectivity]({%ns_cookbook connectivity%}): Lets you check the type of Internet connection and monitor its state changes.
 
 ### Device functionality modules
 
-+ [camera](/cookbook/camera): Lets you take pictures with the device camera.
-+ [location](/cookbook/location): Lets you use the geolocation sensors of the device.
-+ [platform](/cookbook/platform): Provides information about the device, its operating system and software.
-+ [fps-meter](/cookbook/fps-meter): Lets you capture the frames-per-second metrics of your application.
-+ [file-system](/cookbook/file-system): Lets you work with the device file system. Provides high-level abstractions for file system entities such as files, folders, known folders, paths, separators, etc.
-+ [ui/gestures](/cookbook/ui/gestures): Provides the `GesturesObserver` class which lets you observe and respond to user gestures.
++ [camera]({%ns_cookbook camera%}): Lets you take pictures with the device camera.
++ [location]({%ns_cookbook location%}): Lets you use the geolocation sensors of the device.
++ [platform]({%ns_cookbook platform%}): Provides information about the device, its operating system and software.
++ [fps-meter]({%ns_cookbook fps-meter%}): Lets you capture the frames-per-second metrics of your application.
++ [file-system]({%ns_cookbook file-system%}): Lets you work with the device file system. Provides high-level abstractions for file system entities such as files, folders, known folders, paths, separators, etc.
++ [ui/gestures]({%ns_cookbook ui/gestures%}): Provides the `GesturesObserver` class which lets you observe and respond to user gestures.
 
 ### Data modules
 
-+ [data/observable](/cookbook/data/observable): Provides the `Observable` class which represents an observable object or data in the MVVM paradigm.
-+ [data/observable-array](/cookbook/data/observable-array): Provides the `ObservableArray` class which detects and responds to changes in a collection of objects.
-+ [data/virtual-array](/cookbook/data/virtual-array): Provides the `VirtualArray` class which is an advanced array-like class that helps loading items on demand.
++ [data/observable]({%ns_cookbook data/observable%}): Provides the `Observable` class which represents an observable object or data in the MVVM paradigm.
++ [data/observable-array]({%ns_cookbook data/observable-array%}): Provides the `ObservableArray` class which detects and responds to changes in a collection of objects.
++ [data/virtual-array]({%ns_cookbook data/virtual-array%}): Provides the `VirtualArray` class which is an advanced array-like class that helps loading items on demand.
 
 ### User interface modules
 
-+ [ui/frame](/cookbook/ui/frame): Provides the `Frame` class which represents the logical `View` unit that is responsible for navigation within an application.
-+ [ui/page](/cookbook/ui/page): Provides the `Page` class which represents a logical unit for navigation inside a `Frame`. NativeScript apps consist of pages.
-+ [color](/cookbook/color): Lets you create colors which you can use when you style the UI.
-+ [text/formatted-string](/cookbook/formatted-string): Provides the `FormattedString` and `Span` classes which you can use to create rich text formatted strings.
-+ [xml](/cookbook/xml): Provides the `XmlParser` class which is a SAX parser using the easysax implementation.
-+ [ui/styling](/cookbook/ui/styling): Provides the `Style` class which is responsible for the visual appearance of elements.
-+ [ui/animation](/cookbook/ui/animation): Provides the `Animation` class which lets you animate view properties.
++ [ui/frame]({%ns_cookbook ui/frame%}): Provides the `Frame` class which represents the logical `View` unit that is responsible for navigation within an application.
++ [ui/page]({%ns_cookbook ui/page%}): Provides the `Page` class which represents a logical unit for navigation inside a `Frame`. NativeScript apps consist of pages.
++ [color]({%ns_cookbook color%}): Lets you create colors which you can use when you style the UI.
++ [text/formatted-string]({%ns_cookbook formatted-string%}): Provides the `FormattedString` and `Span` classes which you can use to create rich text formatted strings.
++ [xml]({%ns_cookbook xml%}): Provides the `XmlParser` class which is a SAX parser using the easysax implementation.
++ [ui/styling]({%ns_cookbook ui/styling%}): Provides the `Style` class which is responsible for the visual appearance of elements.
++ [ui/animation]({%ns_cookbook ui/animation%}): Provides the `Animation` class which lets you animate view properties.
 
 
 #### Layouts
 
-+ [ui/layouts/stack-layout](/cookbook/ui/layouts/stack-layout): Provides the `StackLayout` class which lets you arrange the children of the layout in a single line.
-+ [ui/layouts/grid-layout](/cookbook/ui/layouts/grid-layout): Provides the `GridLayout` class which lets you arrange the children of the layout in a flexible grid area with columns and rows.
-+ [ui/layouts/absolute-layout](/cookbook/ui/layouts/absolute-layout): Provides the `AbsoluteLayout` class which lets you arrange the children of the layout at arbitrary positions or draw them in multiple layers.
-+ [ui/layouts/wrap-layout](/cookbook/ui/layouts/wrap-layout): Provides the `WrapLayout` class which lets you arrange the children of the layout at sequential positions from left to right and then wrap the lines of children from top to bottom.
++ [ui/layouts/stack-layout]({%ns_cookbook ui/layouts/stack-layout%}): Provides the `StackLayout` class which lets you arrange the children of the layout in a single line.
++ [ui/layouts/grid-layout]({%ns_cookbook ui/layouts/grid-layout%}): Provides the `GridLayout` class which lets you arrange the children of the layout in a flexible grid area with columns and rows.
++ [ui/layouts/absolute-layout]({%ns_cookbook ui/layouts/absolute-layout%}): Provides the `AbsoluteLayout` class which lets you arrange the children of the layout at arbitrary positions or draw them in multiple layers.
++ [ui/layouts/wrap-layout]({%ns_cookbook ui/layouts/wrap-layout%}): Provides the `WrapLayout` class which lets you arrange the children of the layout at sequential positions from left to right and then wrap the lines of children from top to bottom.
 
 #### Widgets
 
-+ [ui/activity-indicator](/cookbook/ui/activity-indicator): Provides the `ActivityIndicator` class which represents a widget for showing that a service is currently busy.
-+ [ui/button](/cookbook/ui/button): Provides the `Button` class which is a standard button widget.
-+ [ui/label](/cookbook/ui/label): Provides the `Label` class which is a standard label widget.
-+ [ui/text-field](/cookbook/ui/text-field): Provides the `TextField` class which represents an editable single-line box.
-+ [ui/text-view](/cookbook/ui/text-view): Provides the `TextView` class which represents an editable multi-line line box.
-+ [ui/list-view](/cookbook/ui/list-view): Provides the `ListView` class which represents a standard list view widget.
-+ [ui/image](/cookbook/ui/image): Provides the `Image` class which represents an image widget.
-+ [ui/progress](/cookbook/ui/progress): Provides the `Progress` class which represents a progress or loading indicator.
-+ [ui/scroll-view](/cookbook/ui/scroll-view): Provides the `ScrollView` class which represents a scrollable area that can show content which is larger than the visible area.
-+ [ui/search-bar](/cookbook/ui/search-bar): Provides the `SearchBar` class which represents a standard search bar component.
-+ [ui/slider](/cookbook/ui/slider): Provides the `Slider` class which represents a standard slider component.
-+ [ui/switch](/cookbook/ui/switch): Provides the `Switch` class which represents a standard switch component.
-+ [ui/tab-view](/cookbook/ui/tab-view): Provides the `TabView` class which represents a standard content component with tabs.
-+ [ui/web-view](/cookbook/ui/web-view): Provides the `WebView` class which represents a standard browser widget.
-+ [ui/html-view](/cookbook/ui/html-view): Provides the `HtmlView` class which represents a standard html view widget.
-+ [ui/dialogs](/cookbook/ui/dialogs): Lets you show various dialogs such as alerts, prompts, confirmations and others.
-+ [ui/list-picker](/cookbook/ui/list-picker): Provides the `ListPicker` class which represents a standard list picker component.
-+ [ui/date-picker](/cookbook/ui/date-picker): Provides the `DatePicker` class which represents a standard date picker component.
-+ [ui/time-picker](/cookbook/ui/time-picker): Provides the `TimePicker` class which represents a standard time picker component.
++ [ui/activity-indicator]({%ns_cookbook ui/activity-indicator%}): Provides the `ActivityIndicator` class which represents a widget for showing that a service is currently busy.
++ [ui/button]({%ns_cookbook ui/button%}): Provides the `Button` class which is a standard button widget.
++ [ui/label]({%ns_cookbook ui/label%}): Provides the `Label` class which is a standard label widget.
++ [ui/text-field]({%ns_cookbook ui/text-field%}): Provides the `TextField` class which represents an editable single-line box.
++ [ui/text-view]({%ns_cookbook ui/text-view%}): Provides the `TextView` class which represents an editable multi-line line box.
++ [ui/list-view]({%ns_cookbook ui/list-view%}): Provides the `ListView` class which represents a standard list view widget.
++ [ui/image]({%ns_cookbook ui/image%}): Provides the `Image` class which represents an image widget.
++ [ui/progress]({%ns_cookbook ui/progress%}): Provides the `Progress` class which represents a progress or loading indicator.
++ [ui/scroll-view]({%ns_cookbook ui/scroll-view%}): Provides the `ScrollView` class which represents a scrollable area that can show content which is larger than the visible area.
++ [ui/search-bar]({%ns_cookbook ui/search-bar%}): Provides the `SearchBar` class which represents a standard search bar component.
++ [ui/slider]({%ns_cookbook ui/slider%}): Provides the `Slider` class which represents a standard slider component.
++ [ui/switch]({%ns_cookbook ui/switch%}): Provides the `Switch` class which represents a standard switch component.
++ [ui/tab-view]({%ns_cookbook ui/tab-view%}): Provides the `TabView` class which represents a standard content component with tabs.
++ [ui/web-view]({%ns_cookbook ui/web-view%}): Provides the `WebView` class which represents a standard browser widget.
++ [ui/html-view]({%ns_cookbook ui/html-view%}): Provides the `HtmlView` class which represents a standard html view widget.
++ [ui/dialogs]({%ns_cookbook ui/dialogs%}): Lets you show various dialogs such as alerts, prompts, confirmations and others.
++ [ui/list-picker]({%ns_cookbook ui/list-picker%}): Provides the `ListPicker` class which represents a standard list picker component.
++ [ui/date-picker]({%ns_cookbook ui/date-picker%}): Provides the `DatePicker` class which represents a standard date picker component.
++ [ui/time-picker]({%ns_cookbook ui/time-picker%}): Provides the `TimePicker` class which represents a standard time picker component.
 + [ui/placeholder]({%slug placeholder %}): Provides the `Placeholder` class which lets you add a native widget to the visual tree.
 
 ### WHATWG Polyfills
 
-+ [fetch](/cookbook/fetch): The `Fetch` polyfill that provides requests, responses, and the process that binds them: fetching. https://fetch.spec.whatwg.org/
++ [fetch]({%ns_cookbook fetch%}): The `Fetch` polyfill that provides requests, responses, and the process that binds them: fetching. https://fetch.spec.whatwg.org/

--- a/releases/Cross-Platform Modules.md
+++ b/releases/Cross-Platform Modules.md
@@ -727,7 +727,7 @@ application.ios.removeNotificationObserver(observer, UIDeviceBatteryLevelDidChan
 
 - [(#221)](https://github.com/NativeScript/NativeScript/pull/221) View parent exposed in itemLoading event
 
-- [(#214)](https://github.com/NativeScript/NativeScript/pull/214) Repeater component added [Read more...](../cookbook/ui/repeater)
+- [(#214)](https://github.com/NativeScript/NativeScript/pull/214) Repeater component added [Read more...]({%ns_cookbook ui/repeater%})
 
 - [(#207)](https://github.com/NativeScript/NativeScript/pull/207) Optimizations
 

--- a/releases/breaking-changes.md
+++ b/releases/breaking-changes.md
@@ -61,7 +61,7 @@ You cannot create NativeScript plugins with Android native code using Eclipse pr
 
 ### 1.2.0 (2015, July 24)
 
-There are changes in how the **Android ActionBar/IOS NavigationBar** is configured. UI is now defined with `page.actionBar` instead of `page.optionsMenu`. [See an example...](http://docs.nativescript.org/cookbook/ui/action-bar)
+There are changes in how the **Android ActionBar/IOS NavigationBar** is configured. UI is now defined with `page.actionBar` instead of `page.optionsMenu`. [See an example...]({%ns_cookbook ui/action-bar%})
 
 ### 0.10.0 (2015, April 17)
 

--- a/tutorial/chapter-2.md
+++ b/tutorial/chapter-2.md
@@ -80,7 +80,7 @@ var applicationModule = require("application");
 applicationModule.start({ moduleName: "views/login/login" });
 ```
 
-Here, you're requiring, or importing, the [NativeScript application module](/cookbook/application). Then, you call its `start()` method with the starting screen of your app (the login screen), which lives in your app's `views/login` folder.
+Here, you're requiring, or importing, the [NativeScript application module]({%ns_cookbook application%}). Then, you call its `start()` method with the starting screen of your app (the login screen), which lives in your app's `views/login` folder.
 
 > **TIP**: JavaScript modules in NativeScript follow the [CommonJS specification](http://wiki.commonjs.org/wiki/CommonJS). This means you can use the [`require()` method](http://wiki.commonjs.org/wiki/Modules/1.1#Module_Context) to import modules, as is done above, as well as use the `export` keyword to expose a module's properties and methods, which we'll look at later in this chapter. These are the same constructs Node.js uses for JavaScript modules, so if you know how to use Node.js modules, you already know how to use NativeScript modules.
 
@@ -138,11 +138,11 @@ Currently you only see a single button because you need to tell NativeScript how
 
 NativeScript provides several different layout containers that allow you to place UI components precisely where you want them to appear. 
 
-- The [Absolute Layout](/cookbook/ui/layouts/absolute-layout) lets you position elements using explicit x and y coordinates. This is useful when you need to place elements in exact locations, for example showing an activity indicator widget in the top-left corner of your app.
-- The [Dock Layout](/cookbook/ui/layouts/dock-layout) is useful for placing UI elements at the outer edges of your app. For example, a container docked at the bottom of the screen would be a good location for an ad.
-- The [Grid Layout](/cookbook/ui/layouts/grid-layout) lets you divide your interface into a series of rows and columns, much like a `<table>` in HTML markup.
-- The [Stack Layout](/cookbook/ui/layouts/stack-layout) lets you stack child UI components either vertically or horizontally.
-- The [Wrap Layout](/cookbook/ui/layouts/wrap-layout) lets child UI components flow from one row or column to the next when space is filled.
+- The [Absolute Layout]({%ns_cookbook ui/layouts/absolute-layout%}) lets you position elements using explicit x and y coordinates. This is useful when you need to place elements in exact locations, for example showing an activity indicator widget in the top-left corner of your app.
+- The [Dock Layout]({%ns_cookbook ui/layouts/dock-layout%}) is useful for placing UI elements at the outer edges of your app. For example, a container docked at the bottom of the screen would be a good location for an ad.
+- The [Grid Layout]({%ns_cookbook ui/layouts/grid-layout%}) lets you divide your interface into a series of rows and columns, much like a `<table>` in HTML markup.
+- The [Stack Layout]({%ns_cookbook ui/layouts/stack-layout%}) lets you stack child UI components either vertically or horizontally.
+- The [Wrap Layout]({%ns_cookbook ui/layouts/wrap-layout%}) lets child UI components flow from one row or column to the next when space is filled.
 
 For your login screen, all you need is a simple `<StackLayout>` to stack the UI components on top of each other. In later sections, you'll use some of the more advanced layouts.
 

--- a/tutorial/chapter-4.md
+++ b/tutorial/chapter-4.md
@@ -49,7 +49,7 @@ Next, take a look in the `app/shared/view-models` folder, which contains a few v
 
 > **NOTE**: In a larger app, it's pretty common to place code that interacts with the backend in separate files, and not directly in the view models. But in our case, the connection code lives directly in the view model for simplicity—which is perfectly reasonable for small apps. 
 
-Note that the `register()` function uses the config module to get the path to the backend, as well as the [fetch module](/cookbook/fetch) to make HTTP calls.
+Note that the `register()` function uses the config module to get the path to the backend, as well as the [fetch module]({%ns_cookbook fetch%}) to make HTTP calls.
 
 ``` JavaScript
 var config = require("../../shared/config");
@@ -154,7 +154,7 @@ To utilize the `Promise` that the view model's `login()` function returns, you n
 
 In the case of Groceries, when the login works you're going to navigate the user to the list page, which you'll be building momentarily, and which will let the user add and remove groceries from a list. To do the navigation you'll use the same frame module you used earlier in this guide.
 
-The trickier situation is handling login failures, and for that you're going to use the dialog module. You can use this module to show [several types](/cookbook/ui/dialogs) of popup UIs in your app, including action sheets, confirmation boxes, alert boxes, and prompts. It is a highly customizable module, and it lets you control the buttons in your alerts, their text, and the messaging in the alert itself. The dialog module's code is in the `node_modules/tns-core-modules/ui` folder with other UI widgets. Let's see how to use this widget on the login page.
+The trickier situation is handling login failures, and for that you're going to use the dialog module. You can use this module to show [several types]({%ns_cookbook ui/dialogs%}) of popup UIs in your app, including action sheets, confirmation boxes, alert boxes, and prompts. It is a highly customizable module, and it lets you control the buttons in your alerts, their text, and the messaging in the alert itself. The dialog module's code is in the `node_modules/tns-core-modules/ui` folder with other UI widgets. Let's see how to use this widget on the login page.
 
 <h4 class="exercise-start">
     <b>Exercise</b>: Handle an error with a dialog window
@@ -227,7 +227,7 @@ Open `app/views/list/list.xml` and paste in the code below, which creates the li
 
 > **NOTE**: Notice that this page is going to use a `<GridLayout>` to layout the UI components on the screen. As you add more UI components, you'll start dividing the screen into rows and columns, but for now you're just going to let the `<ListView>` take up the full screen (which is the default behavior of a `<GridLayout>` with no attributes).
 
-As discussed earlier, even though you're using `<ListView>` in XML, the ListView module is still a NativeScript module. You can find its implementation in the `node_modules/tns-core-modules/ui/list-view` folder. If you want to, you could construct a ListView in pure JavaScript code in the code-behind file as shown in [this example](/cookbook/ui/list-view). For most situations using the NativeScript UI modules in XML is easier, so we'll be sticking with XML usage throughout this tutorial.
+As discussed earlier, even though you're using `<ListView>` in XML, the ListView module is still a NativeScript module. You can find its implementation in the `node_modules/tns-core-modules/ui/list-view` folder. If you want to, you could construct a ListView in pure JavaScript code in the code-behind file as shown in [this example]({%ns_cookbook ui/list-view%}). For most situations using the NativeScript UI modules in XML is easier, so we'll be sticking with XML usage throughout this tutorial.
 
 Note the use of `<ListView.itemTemplate>`. This tag gives you the ability to control how each of the ListView's items displays within the list. For now you're using a simple `<Label>` UI component to display the `{% raw %}{{ name }}{% endraw %}` of each grocery.
 
@@ -590,7 +590,7 @@ The animation module is a lot of fun to play with, and it’s easy to use too. A
 
 Now that you have the login, registration, and list pages complete, let’s enhance the app's functionality as a grocery list management tool. In the next chapters you'll add functionality such as email validation, social sharing, and more. And you'll use one of NativeScript's most useful features to do so: npm modules.
 
-> **TIP**: There are several modules that come out of the box with your NativeScript installation that we did not have time to cover in this guide—including a [location service](/cookbook/location), a [file-system helper](/cookbook/file-system), a [timer module](/cookbook/timer), a [camera module](/cookbook/camera), a [color module](/cookbook/color), and a whole lot more. Make sure to peruse the “Modules API” of the docs, or just look around `node_modules/tns-core-modules` to see all of what's available.
+> **TIP**: There are several modules that come out of the box with your NativeScript installation that we did not have time to cover in this guide—including a [location service]({%ns_cookbook location%}), a [file-system helper]({%ns_cookbook file-system%}), a [timer module]({%ns_cookbook timer%}), a [camera module]({%ns_cookbook camera%}), a [color module]({%ns_cookbook color%}), and a whole lot more. Make sure to peruse the “Modules API” of the docs, or just look around `node_modules/tns-core-modules` to see all of what's available.
 
 <div class="next-chapter-link-container">
   <a href="/tutorial/chapter-5">Continue to Chapter 5—Plugins and npm Modules</a>

--- a/tutorial/ng-chapter-2.md
+++ b/tutorial/ng-chapter-2.md
@@ -173,7 +173,7 @@ Open `app/app.component.ts` and replace the existing `@Component` with the follo
 
 > **WARNING**: Take special care to properly close all your UI elements and _not_ use self-closing declarations like `<Button text="Sign in" />`. The limitation is related to the [parse5 library](https://github.com/inikulin/parse5) Angular 2 uses to parse templates, and you can read [details about the issue on GitHub](https://github.com/NativeScript/nativescript-angular#known-issues).
 
-This code adds two new NativeScript UI elements: a [text field](http://docs.nativescript.org/cookbook/ui/text-field) and a [button](http://docs.nativescript.org/cookbook/ui/button). Much like HTML elements, NativeScript UI elements provide attributes to let you configure their behavior and appearance. The code you just added uses the following attributes:
+This code adds two new NativeScript UI elements: a [text field]({%ns_cookbook ui/text-field%}) and a [button]({%ns_cookbook ui/button%}). Much like HTML elements, NativeScript UI elements provide attributes to let you configure their behavior and appearance. The code you just added uses the following attributes:
 
 - `<TextField>`
     - `hint`: Shows placeholder text that tells the user what to type.
@@ -197,11 +197,11 @@ What went wrong? In NativeScript whenever you use more than one UI element, you 
 
 NativeScript provides several different layout containers that allow you to place UI elements precisely where you want them to appear. 
 
-- The [Absolute Layout](http://docs.nativescript.org/cookbook/ui/layouts/absolute-layout) lets you position elements using explicit x and y coordinates. This is useful when you need to place elements in exact locations, for example showing an activity indicator widget in the top-left corner of your app.
-- The [Dock Layout](http://docs.nativescript.org/cookbook/ui/layouts/dock-layout) is useful for placing UI elements at the outer edges of your app. For example, a container docked at the bottom of the screen would be a good location for an ad.
-- The [Grid Layout](http://docs.nativescript.org/cookbook/ui/layouts/grid-layout) lets you divide your interface into a series of rows and columns, much like a `<table>` in HTML markup.
-- The [Stack Layout](http://docs.nativescript.org/cookbook/ui/layouts/stack-layout) lets you stack child UI elements either vertically or horizontally.
-- The [Wrap Layout](http://docs.nativescript.org/cookbook/ui/layouts/wrap-layout) lets child UI elements flow from one row or column to the next when space is filled.
+- The [Absolute Layout]({%ns_cookbook ui/layouts/absolute-layout%}) lets you position elements using explicit x and y coordinates. This is useful when you need to place elements in exact locations, for example showing an activity indicator widget in the top-left corner of your app.
+- The [Dock Layout]({%ns_cookbook ui/layouts/dock-layout%}) is useful for placing UI elements at the outer edges of your app. For example, a container docked at the bottom of the screen would be a good location for an ad.
+- The [Grid Layout]({%ns_cookbook ui/layouts/grid-layout%}) lets you divide your interface into a series of rows and columns, much like a `<table>` in HTML markup.
+- The [Stack Layout]({%ns_cookbook ui/layouts/stack-layout%}) lets you stack child UI elements either vertically or horizontally.
+- The [Wrap Layout]({%ns_cookbook ui/layouts/wrap-layout%}) lets child UI elements flow from one row or column to the next when space is filled.
 
 For your login screen, all you need is a simple `<StackLayout>` for stacking the UI elements on top of each other. In later sections, you'll use some of the more advanced layouts.
 

--- a/tutorial/ng-chapter-4.md
+++ b/tutorial/ng-chapter-4.md
@@ -708,7 +708,7 @@ If you try out your app you should now see a nice fade-in animation:
 
 Now that you have functional login and list pages, let’s enhance the app’s functionality as a grocery list management tool. In the next chapters you'll add functionality such as email validation, social sharing, and more. And you’ll use one of NativeScript's most useful features to do so: npm modules.
 
-> **TIP**: There are several modules that come out of the box with your NativeScript installation that we did not have time to cover in this guide—including a [location service](https://docs.nativescript.org/cookbook/location), a [file-system helper](https://docs.nativescript.org/cookbook/file-system), a [timer module](https://docs.nativescript.org/cookbook/timer), a [camera module](https://docs.nativescript.org/cookbook/camera), and a whole lot more. Make sure to peruse the “Modules API” of the NativeScript documentation, or just look around your `node_modules/tns-core-modules` folder to see all of what’s available.
+> **TIP**: There are several modules that come out of the box with your NativeScript installation that we did not have time to cover in this guide—including a [location service]({%ns_cookbook location%}), a [file-system helper]({%ns_cookbook file-system%}), a [timer module]({%ns_cookbook timer%}), a [camera module]({%ns_cookbook camera%}), and a whole lot more. Make sure to peruse the “Modules API” of the NativeScript documentation, or just look around your `node_modules/tns-core-modules` folder to see all of what’s available.
 
 <div class="next-chapter-link-container">
   <a href="ng-chapter-5">Continue to Chapter 5—Plugins and npm Modules</a>

--- a/ui/layout-containers.md
+++ b/ui/layout-containers.md
@@ -13,7 +13,7 @@ previous_url: /layout-containers
 * [StackLayout](#stacklayout)
 * [WrapLayout](#wraplayout)
 
-## [AbsoluteLayout](/cookbook/ui/layouts/absolute-layout)
+## [AbsoluteLayout]({%ns_cookbook ui/layouts/absolute-layout%})
 The AbsoluteLayout is the simplest layout in NativeScript. It uses absolute left-top coordinates to position its children. The AbsoluteLayout will not enforce any layout constraints on its children and will not resize them at runtime when its size changes.
 
 ### AbsoluteLayout Properties
@@ -61,7 +61,7 @@ None.
 
 ![AbsoluteLayout](../img/modules/layouts/absolute-layout2.png "AbsoluteLayout")
 
-## [DockLayout](/cookbook/ui/layouts/dock-layout)
+## [DockLayout]({%ns_cookbook ui/layouts/dock-layout%})
 The DockLayout is a layout that provides a docking mechanism for child elements to the left, right, top, bottom or center of the layout. To define the docking side of a child element, use its `dock` property. To dock a child element to the center of the DockLayout, it must be the last child of the DockLayout and the `stretchLastChild` property of the DockLayout must be set to `true`.
 
 ### DockLayout Properties
@@ -131,7 +131,7 @@ The DockLayout is a layout that provides a docking mechanism for child elements 
 
 ![DockLayout](../img/modules/layouts/dock-layout3.png "DockLayout2")
 
-## [GridLayout](/cookbook/ui/layouts/grid-layout)
+## [GridLayout]({%ns_cookbook ui/layouts/grid-layout%})
 The GridLayout is a layout that arranges its child elements in a table structure of rows and columns. A cell can contain multiple child elements, they can span over multiple rows and columns, and even overlap each other. The GridLayout has one column and one row by default. To add additional columns and rows, you have to specify column definition items (separated by commas) to the `columns` property and row definition items (separated by commas) to the `rows` property of the GridLayout. The width of a column and the height of a row can be specified as an absolute amount of pixels, as a percentage of the available space or automatically:
 - **Absolute**: Fixed size of pixels.
 - **Star (\*)**: Takes as much space as available (after filling all auto and fixed sized columns), proportionally divided over all star-sized columns. So 3*/7* means the same as 30*/70*.
@@ -276,7 +276,7 @@ Label 3 has a fixed width of 150 pixels. Label 1 is given more space than it act
 
 ![GridLayout](../img/modules/layouts/grid-layout5.png "GridLayout")
 
-## [StackLayout](/cookbook/ui/layouts/stack-layout)
+## [StackLayout]({%ns_cookbook ui/layouts/stack-layout%})
 The StackLayout stacks its child elements below or beside each other, depending on its orientation. It is very useful to create lists.
 
 ### StackLayout Properties
@@ -363,7 +363,7 @@ None.
 
 ![StackLayout](../img/modules/layouts/stack-layout4.png "StackLayout")
 
-## [WrapLayout](/cookbook/ui/layouts/wrap-layout)
+## [WrapLayout]({%ns_cookbook ui/layouts/wrap-layout%})
 The WrapLayout is similar to the StackLayout, but it does not just stack all child elements to one column/row, it wraps them to new columns/rows if no space is left. The WrapLayout is often used with items of the same size, but this is not a requirement.
 ### WrapLayout Properties
 | Property    | Description |

--- a/ui/layouts.md
+++ b/ui/layouts.md
@@ -114,11 +114,11 @@ The following table shows predefined layouts that NativeScript provides.
 [views]: {%slug components %}
 [View]: /api-reference/classes/_ui_core_view_.view.html
 [Layout]: /api-reference/classes/_ui_layouts_layout_.layout.html
-[AbsoluteLayout]: /cookbook/ui/layouts/absolute-layout
-[DockLayout]: /cookbook/ui/layouts/dock-layout
-[GridLayout]: /cookbook/ui/layouts/grid-layout
-[StackLayout]: /cookbook/ui/layouts/stack-layout
-[WrapLayout]: /cookbook/ui/layouts/wrap-layout
+[AbsoluteLayout]: {%ns_cookbook ui/layouts/absolute-layout%}
+[DockLayout]: {%ns_cookbook ui/layouts/dock-layout%}
+[GridLayout]: {%ns_cookbook ui/layouts/grid-layout%}
+[StackLayout]: {%ns_cookbook ui/layouts/stack-layout%}
+[WrapLayout]: {%ns_cookbook ui/layouts/wrap-layout%}
 
 ### Percentage Support
 

--- a/ui/ui-images.md
+++ b/ui/ui-images.md
@@ -25,7 +25,7 @@ The prefix of the `src` value specifies where the image will be loaded form. The
 * [From local file system (`~/` prefix)](#load-images-from-local-file-system)
 * [From resource (`res://` prefix)](#load-images-from-resource)
 
-You can also use the [image-source](/cookbook/image-source) module to create an image source and manually set it to the image:
+You can also use the [image-source]({%ns_cookbook image-source%}) module to create an image source and manually set it to the image:
 
 ```JavaScript
 var image = new imageModule.Image();
@@ -42,7 +42,7 @@ Web images have an `http://` or `https://` prefix. When such an image is loaded,
 <Image src="https://www.google.com/images/errors/logo_sm_2.png" />
 ```
 
-You can manually create an [ImageSource instance from URL](/cookbook/image-source#load-image-from-url).
+You can manually create an [ImageSource instance from URL]({%ns_cookbook image-source#load-image-from-url%}).
 
 ## Load images from local file system
 Using the `~/` prefix, you can load images relative to the `App` folder inside your project.
@@ -51,7 +51,7 @@ Using the `~/` prefix, you can load images relative to the `App` folder inside y
 <Image src="~/images/logo.png" stretch ="none" />
 ```
 
-You can manually create an [ImageSource instance from local file](/cookbook/image-source#load-image-from-a-local-file).
+You can manually create an [ImageSource instance from local file]({%ns_cookbook image-source#load-image-from-a-local-file%}).
 
 > Currently, loading images from the file system does not respect filename qualifiers as described [here]({% slug architecture %}#supporting-multiple-screens). We have plans to implement that along with [density-specific qualifiers support](https://github.com/NativeScript/NativeScript/issues/276).
 
@@ -62,7 +62,7 @@ Using the `res://` prefix you can load a resource image. This is the suggested a
 <Image src="res://logo" stretch ="none" />
 ```
 
-You can manually create an [ImageSource instance from resource](/cookbook/image-source#load-image-using-resource-name).
+You can manually create an [ImageSource instance from resource]({%ns_cookbook image-source#load-image-using-resource-name%}).
 
 > The file extension is not included when referencing resource images.
 

--- a/ui/ui-views.md
+++ b/ui/ui-views.md
@@ -41,7 +41,7 @@ Defining the layout of the application is also an important part of the applicat
 
 ## Button
 
-The [Button](/cookbook/ui/button) widget provides a standard button widget that reacts to a `tap` event.
+The [Button]({%ns_cookbook ui/button%}) widget provides a standard button widget that reacts to a `tap` event.
 
 ![button android](../img/gallery/android/buttonPage.png "button android")![button ios](../img/gallery/ios/buttonPage.png "button ios")
 
@@ -53,7 +53,7 @@ The [Button](/cookbook/ui/button) widget provides a standard button widget that 
 
 ## Label
 
-The [Label](/cookbook/ui/label) widget provides a text label that shows read-only text.
+The [Label]({%ns_cookbook ui/label%}) widget provides a text label that shows read-only text.
 
 ![label android](../img/gallery/android/labelPage.png "label android")![label ios](../img/gallery/ios/labelPage.png "label ios")
 
@@ -65,7 +65,7 @@ The [Label](/cookbook/ui/label) widget provides a text label that shows read-onl
 
 ## TextField
 
-The [TextField](/cookbook/ui/text-field) widget provides an editable **single-line** text field.
+The [TextField]({%ns_cookbook ui/text-field%}) widget provides an editable **single-line** text field.
 
 ![text-field android](../img/gallery/android/textFieldPage.png "text-field android")![text-field ios](../img/gallery/ios/textFieldPage.png "text-field ios")
 
@@ -77,7 +77,7 @@ The [TextField](/cookbook/ui/text-field) widget provides an editable **single-li
 
 ## TextView
 
-The [TextView](/cookbook/ui/text-view) widget provides an editable **multi-line** text view. 
+The [TextView]({%ns_cookbook ui/text-view%}) widget provides an editable **multi-line** text view. 
 
 You can use it to show multi-line text and implement text editing.
 
@@ -91,7 +91,7 @@ You can use it to show multi-line text and implement text editing.
 
 ## SearchBar
 
-The [SearchBar](/cookbook/ui/search-bar) widget provides a user interface for entering search queries and submitting requests to the search provider.
+The [SearchBar]({%ns_cookbook ui/search-bar%}) widget provides a user interface for entering search queries and submitting requests to the search provider.
 
 ![search-bar android](../img/gallery/android/searchBarPage.png "search-bar android")![search-bar ios](../img/gallery/ios/searchBarPage.png "search-bar ios")
 
@@ -103,7 +103,7 @@ The [SearchBar](/cookbook/ui/search-bar) widget provides a user interface for en
 
 ## Switch
 
-The [Switch](/cookbook/ui/switch) widget provides a two-state toggle switch from which you can choose between two options.
+The [Switch]({%ns_cookbook ui/switch%}) widget provides a two-state toggle switch from which you can choose between two options.
 
 ![switch android](../img/gallery/android/switchPage.png "switch android")![switch ios](../img/gallery/ios/switchPage.png "switch ios")
 
@@ -115,7 +115,7 @@ The [Switch](/cookbook/ui/switch) widget provides a two-state toggle switch from
 
 ## Slider
 
-The [Slider](/cookbook/ui/slider) widget provides a slider that you can use to pick a numeric value within a configurable range.
+The [Slider]({%ns_cookbook ui/slider%}) widget provides a slider that you can use to pick a numeric value within a configurable range.
 
 ![slider android](../img/gallery/android/sliderPage.png "slider android")![slider ios](../img/gallery/ios/sliderPage.png "slider ios")
 
@@ -127,7 +127,7 @@ The [Slider](/cookbook/ui/slider) widget provides a slider that you can use to p
 
 ## Progress
 
-The [Progress](/cookbook/ui/progress) widget is a visual bar indicator of a progress in a operation. It shows a bar representing the current progress of the operation.
+The [Progress]({%ns_cookbook ui/progress%}) widget is a visual bar indicator of a progress in a operation. It shows a bar representing the current progress of the operation.
 
 ![progress android](../img/gallery/android/progressPage.png "progress android")![progress ios](../img/gallery/ios/progressPage.png "progress ios")
 
@@ -139,7 +139,7 @@ The [Progress](/cookbook/ui/progress) widget is a visual bar indicator of a prog
 
 ## ActivityIndicator
 
-The [ActivityIndicator](/cookbook/ui/activity-indicator) widget is a visual spinner indicator which shows that a task is in progress.
+The [ActivityIndicator]({%ns_cookbook ui/activity-indicator%}) widget is a visual spinner indicator which shows that a task is in progress.
 
 ![activity-indicator android](../img/gallery/android/activityIndicatorPage.png "activity-indicator android")![activity-indicator ios](../img/gallery/ios/activityIndicatorPage.png "activity-indicator ios")
 
@@ -151,7 +151,7 @@ The [ActivityIndicator](/cookbook/ui/activity-indicator) widget is a visual spin
 
 ## Image
 
-The [Image](/cookbook/ui/image) widget shows an image. You can load the image from an [`ImageSource`](/api-reference/modules/_image_source_.html) or from a URL.
+The [Image]({%ns_cookbook ui/image%}) widget shows an image. You can load the image from an [`ImageSource`](/api-reference/modules/_image_source_.html) or from a URL.
 
 ![image android](../img/gallery/android/imagePage.png "image android")![image ios](../img/gallery/ios/imagePage.png "image ios")
 
@@ -163,7 +163,7 @@ The [Image](/cookbook/ui/image) widget shows an image. You can load the image fr
 
 ## ListView
 
-The [ListView](/cookbook/ui/list-view) shows items in a vertically scrolling list. You can set an [`itemTemplate`](api-reference/modules/_ui_list_view_.knowntemplates.html) to specify how each item in the list should be displayed.
+The [ListView]({%ns_cookbook ui/list-view%}) shows items in a vertically scrolling list. You can set an [`itemTemplate`](api-reference/modules/_ui_list_view_.knowntemplates.html) to specify how each item in the list should be displayed.
 
 ![list-view android](../img/gallery/android/listViewPage.png "list-view android")![list-view ios](../img/gallery/ios/listViewPage.png "list-view ios")
 
@@ -175,7 +175,7 @@ The [ListView](/cookbook/ui/list-view) shows items in a vertically scrolling lis
 
 ## HtmlView
 
-The [HtmlView](/cookbook/ui/html-view) represents a view with HTML content. Use this component instead of WebView when you want to show just static HTML content.
+The [HtmlView]({%ns_cookbook ui/html-view%}) represents a view with HTML content. Use this component instead of WebView when you want to show just static HTML content.
 
 ![html-view android](../img/gallery/android/htmlViewPage.png "html-view android")![html-view ios](../img/gallery/ios/htmlViewPage.png "html-view ios")
 
@@ -187,7 +187,7 @@ The [HtmlView](/cookbook/ui/html-view) represents a view with HTML content. Use 
 
 ## WebView
 
-The [WebView](/cookbook/ui/web-view) shows web pages. You can load a page from a URL or by navigating back and forward.
+The [WebView]({%ns_cookbook ui/web-view%}) shows web pages. You can load a page from a URL or by navigating back and forward.
 
 ![web-view android](../img/gallery/android/webViewPage.png "web-view android")![web-view ios](../img/gallery/ios/webViewPage.png "web-view ios")
 
@@ -199,7 +199,7 @@ The [WebView](/cookbook/ui/web-view) shows web pages. You can load a page from a
 
 ## TabView
 
-With the [TabView](/cookbook/ui/tab-view) control, you can implement tab navigation.
+With the [TabView]({%ns_cookbook ui/tab-view%}) control, you can implement tab navigation.
 
 ![tab-view android](../img/gallery/android/tabViewPage.png "tab-view android")![tab-view ios](../img/gallery/ios/tabViewPage.png "tab-view ios")
 
@@ -211,7 +211,7 @@ With the [TabView](/cookbook/ui/tab-view) control, you can implement tab navigat
 
 ## SegmentedBar
 
-With the [SegmentedBar](/cookbook/ui/segmented-bar) control, you can implement discrete selection.
+With the [SegmentedBar]({%ns_cookbook ui/segmented-bar%}) control, you can implement discrete selection.
 
 ![segmented-bar android](../img/gallery/android/segmentedBarPage.png "segmented-bar android")![segmented-bar ios](../img/gallery/ios/segmentedBarPage.png "segmented-bar ios")
 
@@ -223,7 +223,7 @@ With the [SegmentedBar](/cookbook/ui/segmented-bar) control, you can implement d
 
 ## DatePicker
 
-With the [DatePicker](/cookbook/ui/date-picker) control, you can pick a date.
+With the [DatePicker]({%ns_cookbook ui/date-picker%}) control, you can pick a date.
 
 ![date-picker android](../img/gallery/android/datePickerPage.png "date-picker android")![date-picker ios](../img/gallery/ios/datePickerPage.png "date-picker ios")
 
@@ -235,7 +235,7 @@ With the [DatePicker](/cookbook/ui/date-picker) control, you can pick a date.
 
 ## TimePicker
 
-With the [TimePicker](/cookbook/ui/time-picker) widget, you can pick a time.
+With the [TimePicker]({%ns_cookbook ui/time-picker%}) widget, you can pick a time.
 
 ![time-picker android](../img/gallery/android/timePickerPage.png "time-picker android")![time-picker ios](../img/gallery/ios/timePickerPage.png "time-picker ios")
 
@@ -247,7 +247,7 @@ With the [TimePicker](/cookbook/ui/time-picker) widget, you can pick a time.
 
 ## ListPicker
 
-With the [ListPicker](/cookbook/ui/list-picker) widget, you can pick a value from a list.
+With the [ListPicker]({%ns_cookbook ui/list-picker%}) widget, you can pick a value from a list.
 
 ![list-picker android](../img/gallery/android/listPickerPage.png "list-picker android")![list-picker ios](../img/gallery/ios/listPickerPage.png "list-picker ios")
 


### PR DESCRIPTION
Make sure we use the correct NS cookbook URL's even in the Angular build.
