### PR TITLE
Fixed code snippet error for Example 15

### DIFF
--- a/ui/animation-css.md
+++ b/ui/animation-css.md
@@ -282,19 +282,23 @@ All keyframes defined in CSS can be accessed with code by using the **getKeyfram
 __Example 15: Accesing CSS defined keyframe in the code via **getKeyframeAnimationWithName** method__
 
 ``` JavaScript
+var keyframeAnimation = require("ui/animation/keyframe-animation");
+
 var view = page.getViewById("view");
 var animationInfo = page.getKeyframeAnimationWithName("bounce");
 animationInfo.duration = 2000;
-var keyframeAnimation = keyframeAnimation.KeyframeAnimation.keyframeAnimationFromInfo(animationInfo);
+var animation = keyframeAnimation.KeyframeAnimation.keyframeAnimationFromInfo(animationInfo);
 animation.play(view).then(() => {
     console.log("Played with code!");
 });
 ```
 ``` TypeScript
+import keyframeAnimation = require("ui/animation/keyframe-animation");
+
 let view = page.getViewById<viewModule.View>("view");
 let animationInfo = page.getKeyframeAnimationWithName("bounce");
 animationInfo.duration = 2000;
-let keyframeAnimation = keyframeAnimation.KeyframeAnimation.keyframeAnimationFromInfo(animationInfo);
+let animation = keyframeAnimation.KeyframeAnimation.keyframeAnimationFromInfo(animationInfo);
 animation.play(view).then(() => {
     console.log("Played with code!");
 });


### PR DESCRIPTION
Fixed an error in the Example 15 code snippet and added info on the necessary `ui/animation/keyframe-animation` import to make code snippet work for improved clarity.
