### PR TITLE
copy editing with several comments to review

### DIFF
--- a/core-concepts/creating-launch-screens-ios.md
+++ b/core-concepts/creating-launch-screens-ios.md
@@ -1,28 +1,34 @@
+---
+title: Creating Launch Screen and AppIcons for iOS
+description: How to set up and modify Launch Screen and AppIcons for iOS
+position: 13
+slug: launch-screen-and-icons-ios
+---
 
 # Creating AppIcons and Launch Screens for iOS 
 
-Publishing your iOS app is essential step in the development process and in order for your iOS Application 
-to be published successfully in App Store there are some requirements that needs to be fulfilled. 
-As described in [iOS Human Interface Guidelines](https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/MobileHIG/IconMatrix.html) setting the following is mandatory:
+Publishing your iOS app is an essential step in the development process and in order for your iOS Application 
+to be published successfully in App Store, there are some requirements that need to be fulfilled. 
+As described in [iOS Human Interface Guidelines](https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/MobileHIG/IconMatrix.html) setting the following is mandatory::
 
 * App name
 * App Icon
 * Launch image or files
 
-In NativeScript your application comes with a pre-defined template settings and images for this steps.
-In this article we are going to introduce the workflow to create your own launch screens.
+In NativeScript your application comes with pre-defined template settings and images for this steps.
+In this article, we are going to introduce the workflow to create your own launch screens..
 
 ## Setting Launch Screen and AppIcons
 
 Setting up launch screens depends on the version of iOS you are targeting.
 In iOS7 and lower the approach for creating launch screen is to use static image resources.
 The drawback of this method is that the app developer will have to provide many different
-images each with different resolution for each iOS device. From iOS8 and above the approach is to create
+images each with a different resolution for each iOS device. From iOS8 and above the approach is to create
 a LaunchScreen.storyboard which is much more powerful in means of customization and is easier to maintain.
 
-The default Hello-World project in NativeScript is provided with default settings that supports both 
-approaches. When build on devices with iOS lower then version 8 it will use the static images and when build
-on device with iOS 8 and above it will use the provided LaunchScreen.storyboard.
+The default Hello-World project in NativeScript is provided with default settings that support both 
+approaches. When building on devices with iOS lower than version 8 it will use the static images 
+and when building on the device with iOS 8 and above it will use the provided LaunchScreen.storyboard..
 
 ### How to set your Launch Screen
 
@@ -88,7 +94,7 @@ If your images have different file names then open Contents.json and change the 
 | 1536x2048        | Default-Portrait@2x.png             |
 | 2048x1536        | Default-Landscape@2x.png            |
 
-> **Note: ** For better understanding of the supported image resolutions for the different iOS devices reffer to [iOS Human Interface Guidelines](https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/MobileHIG/IconMatrix.html#//apple_ref/doc/uid/TP40006556-CH27-SW1)
+> **Note: ** For better understanding of the supported image resolutions for the different iOS devices refer to [iOS Human Interface Guidelines](https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/MobileHIG/IconMatrix.html#//apple_ref/doc/uid/TP40006556-CH27-SW1)
 or check our reference table 
 
 + Xcode WYSIWYG approach
@@ -109,23 +115,23 @@ The first one named LaunchScreen.AspectFill.imageset is used to visualize our ba
 The second one named LaunchScreen.Center.imageset is used to visualize our centered logo.
 Your own storyboard can be customized to use own logic wit different images and styles.
 However keep in mind that according to iOS Human Interface Guidelines the LaunchScreen should be as light as possible
-with minimum or none moving elements and text labels.It is meant to provide immidiat UX rather then artistic presentation.
+with minimum or none moving elements and text labels.It is meant to provide immediate UX rather than artistic presentation..
 
 #### Customizing LaunchScreen.AspectFill
 
 + Manual approach 
 	
 Open **LaunchScreen.AspectFill.imageset** and change the default LaunchScreen.AspectFill images with your own using the proper scale for each image (1x, 2x and 3x).
-As this is an image that will be used in yout LaunchScreen.storyboard your actual resolution may vary depending on your design.
+As this is an image that will be used in your LaunchScreen.storyboard your actual resolution may vary depending on your design.
 The default NativeScript template ships a LaunchScreen-AspectFill.png and LaunchScreen-AspectFill@2x.png used as a sample background.
 If your images have different file names then open Contents.json and change the key `filename` for each image.
 
-> **Important:** After each file change in the **Assets.xcassets** folder you should re-build your project and restart your emulator to avoid visualising cached images.
+> **Important:** After each file change in the **Assets.xcassets** folder you should re-build your project and restart your emulator to avoid visualizing cached images.
 
 + Xcode WYSIWYG approach
 	
 Drag and drop your **Assets.xcassets** into Xcode (7.1 or newer version).
-In the opened window choose **LaunchScreen.AspectFill** and add the proper scaled image for each entry (1x, 2x and 3x).
+In the opened window choose **LaunchScreen.AspectFill** and add the properly scaled image for each entry (1x, 2x and 3x).
 Close Xcode and rebuild your NativeScript app to use the new LaunchScreen.AspectFill.
 
 ![LaunchScreen.AspectFill setup in Xcode](../img/launch-screen/ios/launch-screen-howto-005.png "LaunchScreen.AspectFill setup in Xcode")
@@ -135,16 +141,16 @@ Close Xcode and rebuild your NativeScript app to use the new LaunchScreen.Aspect
 + Manual approach 
 
 Open **LaunchScreen.Center.imageset** and change the default LaunchScreen.Center images with your own using the proper scale for each image (1x, 2x and 3x).
-As this is an image that will be used in yout LaunchScreen.storyboard your actual resolution may vary depending on your design.
+As this is an image that will be used in your LaunchScreen.storyboard your actual resolution may vary depending on your design.
 The default NativeScript template ships a LaunchScreen-Center.png and LaunchScreen-Center@2x.png used as a sample center logo image.
 If your images have different file names then open Contents.json and change the key `filename` for each image.
 
-> **Important:** After each file change in the **Assets.xcassets** folder you should re-build your project and restart your emulator to avoid visualising cached images.
+> **Important:** After each file change in the **Assets.xcassets** folder you should re-build your project and restart your emulator to avoid visualizing cached images.
 
 + Xcode WYSIWYG approach
 
 Drag and drop your **Assets.xcassets** into Xcode (7.1 or newer version).
-In the opened window choose **LaunchScreen.Center** and add the proper scaled image for each entry (1x, 2x and 3x).
+In the opened window choose **LaunchScreen.Center** and add the properly scaled image for each entry (1x, 2x and 3x).
 Close Xcode and rebuild your NativeScript app to use the new LaunchScreen.Center.
 
 ![LaunchScreen.Center setup in Xcode](../img/launch-screen/ios/launch-screen-howto-006.png "LaunchScreen.Center setup in Xcode")

--- a/hardware/location.md
+++ b/hardware/location.md
@@ -10,11 +10,11 @@ previous_url: /location
 
 > **IMPORTANT:** Starting with NativeScript 1.5.0, the built-in Location module is deprecated. To implement geolocation in your apps, use the `nativescript-geolocation` plugin, available via npm. This plugin provides an API similar to the [WC3 Geolocation API](http://dev.w3.org/geo/api/spec-source.html). 
 
-The most important difference between the deprecated module and the new plugin is that location monitoring via the plugin returns an `id` which you can use to stop location monitoring. The `nativescript-geolocation` plugin also uses an accuracy criteria approach to deliver geolocation. This means that getting a location is powered by the most accurate location provider that is available. For example, if GPS signal is available and the GPS provider is enabled, the plugin uses GPS; if GPS is not connected, the device falls back to other available providers such as Wi-Fi networks or cell towers).
+The most important difference between the deprecated module and the new plugin is that location monitoring via the plugin returns an `id` that you can use to stop location monitoring. The `nativescript-geolocation` plugin also uses an accuracy criteria approach to deliver geolocation. This means that getting a location is powered by the most accurate location provider that is available. For example, if a GPS signal is available and the GPS provider is enabled, the plugin uses GPS; if GPS is not connected, the device falls back to other available providers such as Wi-Fi networks or cell towers).
 
 This approach does not limit location monitoring only to a specific location provider; it can still work with all of them.
 
-You might want to start with this [example](https://github.com/nsndeck/locationtest) which demonstrates how to use the `nativescript-geolocation` plugin.
+You might want to start with this [example](https://github.com/nsndeck/locationtest), which demonstrates how to use the `nativescript-geolocation` plugin.
 
 To make the plugin available in your app, run the following command:
 
@@ -22,7 +22,7 @@ To make the plugin available in your app, run the following command:
 tns plugin add nativescript-geolocation
 ```
 
-To import the module in your code use:
+To import the module in your code, use:
 {% nativescript %}
 ```JavaScript
 var geolocation = require("nativescript-geolocation");
@@ -32,19 +32,21 @@ var geolocation = require("nativescript-geolocation");
 import geolocation = require("nativescript-geolocation");
 ```
 
-## Getting Information About a Location Service
+## Getting information about a location service
 
-NativeScript has an universal way to check if location services are turned on - the `isEnabled` method. The method returns a boolean value (true if the location service is enabled).
+NativeScript has a universal way to check if location services are turned on&mdash;the `isEnabled` method. The method returns a Boolean value (true if the location service is enabled).
 
 > **NOTE:** For Android, `isEnabled` checks if the location service is enabled (any accuracy level). For iOS, the method checks if the location service is enabled for the application in foreground or background mode.
 
-> **NOTE:** Keep in mind that location services do not work in emulators. You can test them only on a real devices.
+> **NOTE:** Keep in mind that location services do not work in emulators. You can test location services only on a real devices.
 
-## Requesting Permissions to Use Location Services
+## Requesting permissions to use location services
 
-By default, the `nativescript-geolocation` plugin adds the required permissions in `AndroidManiest.xml` for Android and `Info.plist` for iOS. For iOS, the plugin adds two dummy string values which serve as message when the platform asks for permission to use location services. You can edit this message later. 
+By default, the `nativescript-geolocation` plugin adds the required permissions in `AndroidManiest.xml` for Android and `Info.plist` for iOS. For iOS, the plugin adds two dummy string values which serve as te message when the platform asks for permission to use location services. You can edit this message later. 
 
-After you install the plugin, you can request to use location services in the app with the following code:
+After you install the plugin, you can request to use location services in the app with the code in __Example 1__:
+>caption Example 1: <Comment: insert an SEO-friendly caption for this code example. If this is two or more code examples, number them and add SEO-friendly captions.>
+
 {% nativescript %}
 ```XML
 <Page> 
@@ -77,7 +79,7 @@ exports.enableLocationTap = enableLocationTap;
 }
 ```
 
-## Getting Location
+## Getting location
 
 You can get location with `getCurrentLocation` or with `watchLocation`. Using `distance`, you can obtain the distance between two locations.
 
@@ -91,10 +93,10 @@ This method gets a single location. It accepts the `location options` parameter.
 
 `getCurrentLocation` returns a `Promise<Location>` where `Location` and `location options` are defined as follows.
 
-#### Class: Location  
+#### Class: location  
 A data class that encapsulates common properties for a geolocation.
 
-##### Instance Properties
+##### Instance properties
 
 Property | Type | Description
 ---|---|---
@@ -109,20 +111,20 @@ Property | Type | Description
 `android` | Object | The Android-specific [location](http://developer.android.com/reference/android/location/Location.html) object.
  `ios` | CLLocation | The iOS-specific [CLLocation](https://developer.apple.com/library/ios/documentation/CoreLocation/Reference/CLLocation_Class/) object.
 
-#### Interface: Options  
+#### Interface: options  
 Provides options for location monitoring.
 
 ##### Properties
 
 Property | Type | Description
 ---|---|---
-`desiredAccuracy` | Number | (Optional) Specifies desired accuracy in meters. Defaults to `DesiredAccuracy.HIGH`
+`desiredAccuracy` | Number | (Optional) Specifies desired accuracy in meters. Defaults to `DesiredAccuracy.HIGH`.
 `updateDistance` | Number | (Optional) Updates distance filter in meters. Specifies how often to update. Default on iOS is no filter, on Android it is 0 meters.
 `minimumUpdateTime` | Number | (Optional) Specifies the minimum time interval between location updates, in milliseconds. Ignored on iOS.
 `maximumAge` | Number | (Optional) Filters locations by how long ago they were received, in milliseconds. For example, if the `maximumAge` is 5000, you will get locations only from the last 5 seconds. 
 `timeout` | Number | (Optional) Specifies how long to wait for a location, in milliseconds.
 
-
+>caption Example 2: <Comment: insert an SEO-friendly caption for this code example.>
 {% nativescript %}
 ```XML
 <Page>
@@ -167,7 +169,10 @@ exports.buttonGetLocationTap = buttonGetLocationTap;
 
 ### `watchLocation`
 
-With this method, location watching does not stop automatically until `clearWatch` method is called. You might need to use this method in apps which require a GPS log or active location tracking.  
+With this method, location watching does not stop automatically until the `clearWatch` method is called. You might need to use this method in apps which require a GPS log or active location tracking. 
+
+>caption Example 3: <Comment: insert an SEO-friendly caption for this code example.>
+
 {% nativescript %}
 ```XML
 <Page>
@@ -232,6 +237,8 @@ exports.buttonStopTap = buttonStopTap;
 ### `distance`
 
 This method lets you measure the distance between two locations in meters.
+
+>caption Example 4: <Comment: insert an SEO-friendly caption for this code example.>
 
 {% nativescript %}
 ```JavaScript

--- a/releases/Android Runtime.md
+++ b/releases/Android Runtime.md
@@ -7,6 +7,24 @@ slug: android-changelog
 previous_url: /Changelogs/Android Runtime
 ---
 
+2.1
+==
+
+## What's New
+
+ - [Implement custom gradle clean (#459)](https://github.com/NativeScript/android-runtime/issues/459)
+
+## Bug Fixes
+
+ - [App crash (#476)](https://github.com/NativeScript/android-runtime/issues/476)
+ - [The static binding generator should clean redundant files (#467)](https://github.com/NativeScript/android-runtime/issues/467)
+ - [Android builds fail on nativescript 2.0  (#460)](https://github.com/NativeScript/android-runtime/issues/460)
+ - [Need to add a Gradle Android.defaultConfig (#454)](https://github.com/NativeScript/android-runtime/issues/454)
+
+## Performance
+
+ - [Initial builds of ng2 apps are slow (#436)](https://github.com/NativeScript/android-runtime/issues/436)
+
 2.0.0
 ==
 

--- a/releases/CLI.md
+++ b/releases/CLI.md
@@ -9,6 +9,41 @@ previous_url: /Changelogs/CLI
 
 NativeScript CLI Changelog
 ================
+2.1.0 (2016, June 30)
+==
+
+### New
+* [Implemented #1773](https://github.com/NativeScript/nativescript-cli/issues/1773): Show warning when livesync cannot reflect a change.
+* [Implemented #1733](https://github.com/NativeScript/nativescript-cli/issues/1733): [node.js 6.x support] Native module sources is not supported.
+* [Implemented #1731](https://github.com/NativeScript/nativescript-cli/issues/1731): Have the quick setup scripts create an AVD emulator.
+* [Implemented #1650](https://github.com/NativeScript/nativescript-cli/issues/1650): Implement a shorthand --tsc option of the create command.
+* [Implemented #1580](https://github.com/NativeScript/nativescript-cli/issues/1580): Add clean commands to tns.
+* [Implemented #1517](https://github.com/NativeScript/nativescript-cli/issues/1517): Allow for apps to disable page reload livesyncs.
+
+### Fixed
+* [Fixed #1883](https://github.com/NativeScript/nativescript-cli/issues/1883): Live sync recompiles the app every time in iOS when run first time.
+* [Fixed #1853](https://github.com/NativeScript/nativescript-cli/issues/1853): Flag when Android devices are out of storage.
+* [Fixed #1826](https://github.com/NativeScript/nativescript-cli/issues/1826): Replace Local Maven repository for Support Libraries with Android Support Repository.
+* [Fixed #1810](https://github.com/NativeScript/nativescript-cli/issues/1810): tns livesync android --emulator --watch fails when create new folder.
+* [Fixed #1790](https://github.com/NativeScript/nativescript-cli/issues/1790): tns publish ios fails with cocoapods.
+* [Fixed #1777](https://github.com/NativeScript/nativescript-cli/issues/1777): Invalid XML kills livesync.
+* [Fixed #1776](https://github.com/NativeScript/nativescript-cli/issues/1776): UnitTest app is packed within the published application which increases the size of the application.
+* [Fixed #1770](https://github.com/NativeScript/nativescript-cli/issues/1770): "tns livesync ios --watch" doesn't sync changes if pacakgeId and folder name does not match.
+* [Fixed #1752](https://github.com/NativeScript/nativescript-cli/issues/1752): Use spaces instead of tabs in package.json for consistency with npm.
+* [Fixed #1746](https://github.com/NativeScript/nativescript-cli/issues/1746): Remove node_modules after preparing plugins.
+* [Fixed #1739](https://github.com/NativeScript/nativescript-cli/issues/1739): NativeScript 2.0 warning needs to reference how to install updated cocoapods when xcode 7.3 supported version of pods is released.
+* [Fixed #1734](https://github.com/NativeScript/nativescript-cli/issues/1734): ios builds with 2.0.0: Processing node_modules failed. TypeError: Cannot read property 'split' of null.
+* [Fixed #1732](https://github.com/NativeScript/nativescript-cli/issues/1732): TNS 2.00 & Macintosh without Java/Android configured.
+* [Fixed #1727](https://github.com/NativeScript/nativescript-cli/issues/1727): [Angular] Improve livesync performance for iOS.
+* [Fixed #1725](https://github.com/NativeScript/nativescript-cli/issues/1725): Ctrl + C shortcut does not stop the livesync ios --watch command.
+* [Fixed #1652](https://github.com/NativeScript/nativescript-cli/issues/1652): Analytics for OS X version.
+* [Fixed #1620](https://github.com/NativeScript/nativescript-cli/issues/1620): Unable to debug on iOS using the --device option.
+* [Fixed #1571](https://github.com/NativeScript/nativescript-cli/issues/1571): Livesync ios is not working when dependency has executable.
+* [Fixed #1481](https://github.com/NativeScript/nativescript-cli/issues/1481): LiveSync doesn't show any changes to a modal page.
+* [Fixed #1376](https://github.com/NativeScript/nativescript-cli/issues/1376): Consider removing --debug-brk parameter.
+* [Fixed #1296](https://github.com/NativeScript/nativescript-cli/issues/1296): tns build breaks permanately if you have drawable-invalid name.
+* [Fixed #485](https://github.com/NativeScript/nativescript-cli/issues/485): Platform specific prepare breaks source map paths.
+
 2.0.1 (2016, May 18)
 ==
 ### Fixed

--- a/releases/Cross-Platform Modules.md
+++ b/releases/Cross-Platform Modules.md
@@ -7,14 +7,7 @@ publish: false
 previous_url: /Changelogs/Cross-Platform Modules
 ---
 
----
-title: Modules Changelog
-description: NativeScript Cross-Platform Modules Changelog
-position: 4
-slug: modules-changelog
-publish: false
-previous_url: /Changelogs/Cross-Platform Modules
----
+
 
 Cross Platform Modules Changelog
 ==============================

--- a/releases/Cross-Platform Modules.md
+++ b/releases/Cross-Platform Modules.md
@@ -19,6 +19,102 @@ previous_url: /Changelogs/Cross-Platform Modules
 Cross Platform Modules Changelog
 ==============================
 
+##2.1.0 (2016, June 30)
+
+### Fixed
+
+- [(#2383)](https://github.com/NativeScript/NativeScript/pull/2383) android LayoutParams are not overridden
+
+- [(#2372)](https://github.com/NativeScript/NativeScript/issues/2372) Custom title on Android fails with exception
+
+- [(#2367)](https://github.com/NativeScript/NativeScript/pull/2367) Android 6.0+ sets activity intent extras by default which breaks application resume
+
+- [(#2344)](https://github.com/NativeScript/NativeScript/pull/2344) Action bar doesn't handle events properly when a custom button
+
+- [(#1655)](https://github.com/nativescript/nativescript/issues/1655) Added CSS not cascadded after screen is built 
+
+- [(#2310)](https://github.com/NativeScript/NativeScript/pull/2310) Sorting issue with Css Selectors with same specificity.
+
+- [(#2301)](https://github.com/NativeScript/NativeScript/pull/2301) Updated webinspector interfaces
+
+- [(#2299)](https://github.com/NativeScript/NativeScript/pull/2299) Binding converter calls.
+
+- [(#2286)](https://github.com/NativeScript/NativeScript/pull/2286) Visual glitch with manual iOS transitions
+
+- [(#2268)](https://github.com/NativeScript/NativeScript/pull/2268) Undefined can be set as localValue to dependency observable
+
+- [(#2266)](https://github.com/NativeScript/NativeScript/pull/2266) Animation value sync issues
+
+- [(#2263)](https://github.com/NativeScript/NativeScript/pull/2263) Crash when ListView is used in a modal dialog (Android).
+
+- [(#2262)](https://github.com/NativeScript/NativeScript/pull/2262) Crash in action bar on iOS 9.3
+
+- [(#2256)](https://github.com/NativeScript/NativeScript/issues/2256) Custom ActionItem gets displaced in iOS
+
+- [(#2250)](https://github.com/NativeScript/NativeScript/pull/2250) Ignore the case when getting a response header
+
+- [(#2240)](https://github.com/NativeScript/NativeScript/issues/2240) Possible regex issue with CSS class names
+
+- [(#2225)](https://github.com/NativeScript/NativeScript/issues/2225) The exit transition of the current page is not played when navigating with clearHistory.
+
+- [(#2220)](https://github.com/NativeScript/NativeScript/pull/2220) Close current modal page on livesync
+
+- [(#2209)](https://github.com/NativeScript/NativeScript/issues/2209) CSS-Animation w/ iteration-count:infinite is never reset causing OutOfMemory error
+
+- [(#2191)](https://github.com/NativeScript/NativeScript/pull/2191) SegmentedBar unbound items not firing selectedIndex change events
+
+- [(#2177)](https://github.com/NativeScript/NativeScript/issues/2177) iOS CSS Animation rotate() do not reset the value after 360 degrees rotation 
+
+- [(#2161)](https://github.com/NativeScript/NativeScript/issues/2161) TranslateX and Animate in iOS strange behaviour on 2.0
+
+- [(#2151)](https://github.com/NativeScript/NativeScript/issues/2151) Add z-index to the public API
+
+- [(#2053)](https://github.com/NativeScript/NativeScript/issues/2053) WebView still visible in chrome://inspect after page is destroyed
+
+- [(#1948)](https://github.com/NativeScript/NativeScript/issues/1948) Navigation stops working after navigating with clearHistory and a transition
+
+- [(#1899)](https://github.com/NativeScript/NativeScript/issues/1899) Android layerType should not be changed if there is no need
+
+- [(#1807)](https://github.com/NativeScript/NativeScript/issues/1807) SearchBar.textFieldHintColor not respected on iOS
+
+- [(#1425)](https://github.com/NativeScript/NativeScript/issues/1425) Images have margin when added to Layout
+
+### New
+
+- [(#1563)](https://github.com/NativeScript/NativeScript/issues/1563) Enable modules snapshot for Android
+- 
+- [(#2339)](https://github.com/NativeScript/NativeScript/pull/2339) Implement the BorderDrawable class used in background.android.ts in Java
+
+- [(#2322)](https://github.com/NativeScript/NativeScript/pull/2322) Added support for debugging TypeScript in WebInspector
+
+- [(#2307)](https://github.com/NativeScript/NativeScript/pull/2307) Modules won't call android requestLayout anymore. Android will handle its layout when needed
+
+- [(#2304)](https://github.com/NativeScript/NativeScript/pull/2304) Rename com.tns.Async.xxx to org.nativescript.widgets.Async.xxx
+
+- [(#2298)](https://github.com/NativeScript/NativeScript/pull/2298) Move UILableImpl as TNSLabel in widgets.
+
+- [(#2288)](https://github.com/NativeScript/NativeScript/pull/2288) Decouple Fragment implementation logic from the Extend call.
+
+- [(#2271)](https://github.com/NativeScript/NativeScript/pull/2271) Extract the Activity implementation logic in a separate class.
+
+- [(#2270)](https://github.com/NativeScript/NativeScript/pull/2270) Avoid excessive requestLayout calls
+
+- [(#2269)](https://github.com/NativeScript/NativeScript/pull/2269) Label won't requestLayout when its text is changed if it has fixed size
+
+- [(#2260)](https://github.com/NativeScript/NativeScript/pull/2260) Optimized DependencyObject setValue performance
+
+- [(#2244)](https://github.com/NativeScript/NativeScript/pull/2244) Remove the android.app.Application extend from the core modules
+
+- [(#2217)](https://github.com/NativeScript/NativeScript/issues/2217) Enable hardware acceleration for views animations in Android.
+
+- [(#2198)](https://github.com/NativeScript/NativeScript/pull/2198) Image won't requestLayout when measured with 'exactly' spec
+
+- [(#2174)](https://github.com/NativeScript/NativeScript/pull/2174) ListView views will apply CSS once per view.
+
+- [(#2144)](https://github.com/NativeScript/NativeScript/issues/2144) Performance improvements
+
+
+
 ##2.0.1 (2016, May 18)
 
 ### Fixed

--- a/releases/Cross-Platform Modules.md
+++ b/releases/Cross-Platform Modules.md
@@ -7,8 +7,6 @@ publish: false
 previous_url: /Changelogs/Cross-Platform Modules
 ---
 
-
-
 Cross Platform Modules Changelog
 ==============================
 

--- a/releases/iOS Runtime.md
+++ b/releases/iOS Runtime.md
@@ -7,14 +7,7 @@ slug: ios-changelog
 previous_url: /Changelogs/iOS Runtime
 ---
 
----
-title: iOS Runtime Changelog
-description: NativeScript iOS Runtime Changelog
-position: 6
-publish: false
-slug: ios-changelog
-previous_url: /Changelogs/iOS Runtime
----
+
 
 
 2.1.0

--- a/releases/iOS Runtime.md
+++ b/releases/iOS Runtime.md
@@ -16,6 +16,16 @@ slug: ios-changelog
 previous_url: /Changelogs/iOS Runtime
 ---
 
+
+2.1.0
+=====
+
+## Bug Fixes
+- Various debugging and LiveSync improvements
+
+## Breaking Changes
+- Removed iOS 7 support
+
 2.0.1
 =====
 


### PR DESCRIPTION
The heading style for NativeScript documentation is sentence case, so just capitalize the first word plus proper nouns.

At least 4 of the code samples need captions. I've added stubs for them.
