### PR TITLE
Fix incorrect ANDROID_HOME installation inctructions

### DIFF
--- a/start/ns-setup-os-x.md
+++ b/start/ns-setup-os-x.md
@@ -80,17 +80,18 @@ Complete the following steps to setup NativeScript on your OS X development mach
         </code></pre>
 
     1. Install the [Android SDK](http://developer.android.com/sdk/index.html).
-        1. In the terminal, run the following command.
+        1. In the terminal, run the following commands:
 
             <pre class="add-copy-button"><code class="language-terminal">brew install android-sdk
             </code></pre>
 
-        1. Set the ANDROID_HOME system environment variable.
+        1. Set the ANDROID_HOME system environment variable
 
-            <pre><code class="language-terminal">export ANDROID_HOME=Path to Android installation directory
+            <pre class="add-copy-button"><code class="language-terminal">export ANDROID_HOME=/usr/local/opt/android-sdk
             </code></pre>
-            For example: `ANDROID_HOME=/usr/local/Cellar/android-sdk/24/`
+            
             <blockquote><b>NOTE</b>: This is the directory that contains the <code>tools</code> and <code>platform-tools</code> directories.</blockquote>
+            
         1. Select all packages for the Android 22 SDK, Android SDK Build-tools 23.0.3 or later, Local Maven repository for Support Libraries (under Extras) and any other SDKs that you want to install and click **Install**. You can alternatively use the following command, which will install all required tools:
 
            <pre class="add-copy-button"><code class="language-terminal">android update sdk --filter tools,platform-tools,android-23,build-tools-23.0.3,extra-android-m2repository,extra-google-m2repository,extra-android-support --all --no-ui


### PR DESCRIPTION
The brew installation creates a symbolic link in `/usr/local/opt/android-sdk` that links to the correct folder the SDK was installed to. `/usr/local/Cellar/android-sdk/24/` is incorrect in my case, because brew installed it in `/usr/local/Cellar/android-sdk/24.4.1_1/` at noted here:
![brew install android-sdk](http://i.imgur.com/CcNEjAt.png)

@NathanaelA has mentioned that without the trailing `/` on `export ANDROID_HOME=/usr/local/opt/android-sdk` it will not work because in TNS it reads the env like so:

``` javascript
var someName = $ENV['ANDROID_HOME'] + PathToExe
```

I have had no such issues without this `/` so someone should double check on it.
