### PR TITLE
Fixed CSS @import syntax

### DIFF
--- a/ui/styling.md
+++ b/ui/styling.md
@@ -413,7 +413,7 @@ If you have doubt about the original font name use [Font Book](https://support.a
 The @import CSS rule allows you to import external CSS from local file, resource or url. These rules must precede all other types of rules.
 
 ```CSS
-@import { url('http://some-domain.com/your-style.css') }
-@import { url('res://your-style.css') }
-@import { url('~/your-style.css') }
+@import: 'http://some-domain.com/your-style.css';
+@import: 'res://your-style.css';
+@import: '~/your-style.css';
 ```


### PR DESCRIPTION
Trying

``` css
@import { url('~/your-style.css') }
```

didn't seem to work.

According to this recent article, [using-css-animations-in-nativescript](https://www.nativescript.org/blog/details/using-css-animations-in-nativescript) it says

``` css
@import: "~/css/animate.css";
```

is the correct syntax.
