### PR TITLE
Fix incorrect class name

### DIFF
--- a/ui/theme.md
+++ b/ui/theme.md
@@ -116,7 +116,7 @@ The NativeScript core theme does not change the base font family you use to deve
 * `font-italic`: A class name to display a font in italic text.
 
 ``` XML
-<Label class="font-weight-bold" text="This text will appear italicized"></Label>
+<Label class="font-italic" text="This text will appear italicized"></Label>
 ```
 
 ### Padding and Margin


### PR DESCRIPTION
The example for italic fonts had the class name `font-weight-bold` instead of `font-italic`.
