### PR TITLE
update installation instruction for lib32bz2-1.0 failure

### DIFF
--- a/start/ns-setup-linux.md
+++ b/start/ns-setup-linux.md
@@ -42,6 +42,9 @@ Complete the following steps to set up NativeScript on your Linux development ma
 
     <pre class="add-copy-button"><code class="language-terminal">sudo apt-get install lib32z1 lib32ncurses5 lib32bz2-1.0 libstdc++6:i386
     </code></pre>
+    If you encounter an error showing "Unable to locate package lib32bz2-1.0" then use
+    <pre class="add-copy-button"><code class="language-terminal">sudo apt-get install lib32z1 lib32ncurses5 libbz2-1.0:i386 libstdc++6:i386
+    </code></pre>
 
 1. Install the G++ compiler.
 


### PR DESCRIPTION
I have ubuntu 16.04 and I had to change lib32bz2-1.0 to  libbz2-1.0:i386 for successful installation
