### PR TITLE
Updated ns-setup-os-x.md for Firebase-Usage

### DIFF
--- a/start/ns-setup-os-x.md
+++ b/start/ns-setup-os-x.md
@@ -87,7 +87,7 @@ Complete the following steps to setup NativeScript on your OS X development mach
 
         1. Next, run the following command to set the ANDROID_HOME system environment variable:
 
-            <pre class="add-copy-button"><code class="language-terminal">export ANDROID_HOME=/usr/local/opt/android-sdk
+            <pre class="add-copy-button"><code class="language-terminal">export ANDROID_HOME=/usr/local/Cellar/android-sdk
             </code></pre>
 
             <blockquote><b>NOTE</b>: This is the directory that contains the <code>tools</code> and <code>platform-tools</code> directories.</blockquote>


### PR DESCRIPTION
If you want to use Firebase with AVD, you´ll need to specify ANDROID_HOME as "/usr/local/Cellar/android-sdk", otherwise it won't recognise Google APIs Intel Atom as the CPU/ABI, which is needed to run Google Play Services (which again is needed for Firebase).

More on this issue:
https://github.com/EddyVerbruggen/nativescript-plugin-firebase/issues/207