### PR TITLE
Update Node.js LTS install via brew on line #25

### DIFF
--- a/start/quick-setup.md
+++ b/start/quick-setup.md
@@ -22,7 +22,7 @@ The NativeScript CLI is built on Node.js, and as such you need to have Node.js i
 You can check whether you have Node.js set up by opening a terminal or command prompt on your development machine and executing `node --version`. If you get an error, head to  <https://nodejs.org/> and download and install the latest “LTS” (long-term support) distribution for your development machine.
 
 > **TIP**:
-> * If you’re on OS X and use [Homebrew](http://brew.sh/), you can alternatively install the Node.js LTS release by running `brew install node4-lts` in your terminal.
+> * If you’re on OS X and use [Homebrew](http://brew.sh/), you can alternatively install the Node.js LTS release by running `brew install homebrew/versions/node4-lts` in your terminal.
 > * The NativeScript CLI supports a wide variety of Node.js versions, so if you already have Node.js installed you should be good to go. If, by chance, you’re running an unsupported version, the `tns doctor` command we’ll run momentarily will flag the problem so you can upgrade.
 
 ## Step 2: Install the NativeScript CLI


### PR DESCRIPTION
On trying `brew install node4-lts`, the terminal threw the following error:

Error: No available formula with the name "node4-lts" 
==> Searching for similarly named formulae...
Error: No similarly named formulae found.
==> Searching taps...
This formula was found in a tap:
homebrew/versions/node4-lts
To install it, run:
brew install homebrew/versions/node4-lts

==========================================================

`brew install homebrew/versions/node4-lts` threw no error:

==> Tapping homebrew/versions
Cloning into '/usr/local/Homebrew/Library/Taps/homebrew/homebrew-versions'...
remote: Counting objects: 222, done.
remote: Compressing objects: 100% (214/214), done.
remote: Total 222 (delta 21), reused 44 (delta 6), pack-reused 0
Receiving objects: 100% (222/222), 268.13 KiB | 195.00 KiB/s, done.
Resolving deltas: 100% (21/21), done.
Tapped 213 formulae (243 files, 987.7K)
==> Installing node4-lts from homebrew/versions
==> Downloading https://homebrew.bintray.com/bottles-versions/node4-lts-4.6.2.yosemite.bottle.tar.gz
######################################################################## 100.0%
==> Pouring node4-lts-4.6.2.yosemite.bottle.tar.gz
==> Caveats
Bash completion has been installed to:
  /usr/local/etc/bash_completion.d
==> Summary
🍺  /usr/local/Cellar/node4-lts/4.6.2: 3,640 files, 35.3M

==========================================================

Verified: 
$ node --version
v4.6.2