### PR TITLE
Remove a sentence that might confuse new users

### DIFF
--- a/start/quick-setup.md
+++ b/start/quick-setup.md
@@ -34,7 +34,6 @@ Open your terminal or command prompt and execute the following command to instal
 > **NOTE**:
 > * You may be asked two questions during the installation—_Do you want to visit the official documentation?_, and _Do you want to run the setup script?_ Go ahead and answer “No” to both questions for now as we’ll cover the documentation and scripts momentarily.
 > * If you’re on OS X and receive an EACCES error, you either need to rerun the previous command with `sudo`—that is, `sudo npm install -g nativescript`—or take a moment to [fix your npm permissions](https://docs.npmjs.com/getting-started/fixing-npm-permissions) so that you don’t need admin rights to globally install npm packages.
-> * nativescript CLI will try detecting your mobile platform SDKs and configure itself against these. If you're seetting up brand new system, consider installing all mobile SDKs prior NativeScript installation.
 
 After completing the setup you should have two commands available from your terminal or command prompt: `tns`—which is short for <b>T</b>elerik <b>N</b>ative<b>S</b>cript—and `nativescript`. The two commands are equivalent, so we'll stick with the shorter `tns`.
 


### PR DESCRIPTION
Ping @donangel.

I’d like to remove this sentence because it has some grammatical issues, and because I think the phrase “all mobile SDKs” may confuse new users that don’t know _which_ mobile SDKs to install.

Could you provide a little more detail on what confused you about this documentation before? We can probably rephrase this or add something different to address your concerns. I also asked the CLI team whether the setup scripts could install Node+npm+tns, which would simplify these instructions considerably.

Thanks.