### PR TITLE
Changed OS X to macOS

### DIFF
--- a/start/ns-setup-linux.md
+++ b/start/ns-setup-linux.md
@@ -14,7 +14,7 @@ This page contains a list of all system requirements needed to build and run Nat
 * [System Requirements](#system-requirements)
 * [Advanced Setup Steps](#advanced-setup-steps)
 
-> **NOTE**: On Linux systems you can only use the NativeScript CLI to develop Android apps. This is because the NativeScript CLI uses Xcode to build iOS apps, which is only available on the OS X operating system. If you’re interested in building iOS apps on Linux, you may want to try out the [Telerik Platform](http://www.telerik.com/platform). The Telerik Platform provides robust tooling for NativeScript apps, including a service that performs iOS and Android builds in the cloud, removing the need to complete these system requirements, and allowing you to build for iOS on Linux.
+> **NOTE**: On Linux systems you can only use the NativeScript CLI to develop Android apps. This is because the NativeScript CLI uses Xcode to build iOS apps, which is only available on the macOS operating system. If you’re interested in building iOS apps on Linux, you may want to try out the [Telerik Platform](http://www.telerik.com/platform). The Telerik Platform provides robust tooling for NativeScript apps, including a service that performs iOS and Android builds in the cloud, removing the need to complete these system requirements, and allowing you to build for iOS on Linux.
 
 ## System Requirements
 

--- a/start/ns-setup-os-x.md
+++ b/start/ns-setup-os-x.md
@@ -1,22 +1,22 @@
 ---
-title: NativeScript Advanced Setup—OS X
-description: Configure your OS X system to create, develop and build projects locally with NativeScript.
+title: NativeScript Advanced Setup—macOS
+description: Configure your macOS system to create, develop and build projects locally with NativeScript.
 position: 40
 publish: false
 slug: osx
 previous_url: /setup/ns-cli-setup/ns-setup-os-x
 ---
 
-# NativeScript Advanced Setup: OS X
+# NativeScript Advanced Setup: macOS
 
-This page contains a list of all system requirements needed to build and run NativeScript apps on OS X, as well as a guided walkthrough for getting these requirements in place. On OS X systems, you can use the NativeScript CLI to develop Android and iOS apps.
+This page contains a list of all system requirements needed to build and run NativeScript apps on macOS, as well as a guided walkthrough for getting these requirements in place. On macOS systems, you can use the NativeScript CLI to develop Android and iOS apps.
 
 * [System Requirements](#system-requirements)
 * [Advanced Setup Steps](#advanced-setup-steps)
 
 ## System Requirements
 
-* OS X Mavericks or later
+* macOS Mavericks or later
 * The latest stable official release of Node.js (LTS) [6.x](https://nodejs.org/dist/latest-v6.x/) 
 * (Optional) Homebrew to simplify the installation of dependencies
 * For iOS development
@@ -39,7 +39,7 @@ You must also have the following two environment variables setup for Android dev
 
 ## Advanced Setup Steps
 
-Complete the following steps to setup NativeScript on your OS X development machine:
+Complete the following steps to setup NativeScript on your macOS development machine:
 
 1. Install [Homebrew](http://brew.sh) to simplify the installation process.
 
@@ -53,7 +53,7 @@ Complete the following steps to setup NativeScript on your OS X development mach
 
 1. Install the dependencies for iOS development.
     1. Run the App Store and download and install Xcode 5 or later.
-    1. Go to [Downloads for Apple Developers](https://developer.apple.com/downloads/index.action), log in and download and install the **Command Line Tools for Xcode** for your version of OS X and Xcode.
+    1. Go to [Downloads for Apple Developers](https://developer.apple.com/downloads/index.action), log in and download and install the **Command Line Tools for Xcode** for your version of macOS and Xcode.
     1. Install the [xcodeproj ruby gem](https://rubygems.org/gems/xcodeproj/versions/0.28.2) with the following command.
 
         <pre class="add-copy-button"><code class="language-terminal">sudo gem install xcodeproj
@@ -72,7 +72,7 @@ Complete the following steps to setup NativeScript on your OS X development mach
 1. Install the dependencies for Android development.
     1. Install [JDK 8](http://www.oracle.com/technetwork/java/javase/downloads/index.html) or a later stable official release.
         1. Go to [Java SE Downloads](http://www.oracle.com/technetwork/java/javase/downloads/index.html) and click **Download** for JDK.
-        1. In the **Java SE Development Kit** section, accept the license agreement and click the download link for Mac OS X.
+        1. In the **Java SE Development Kit** section, accept the license agreement and click the download link for Mac macOS.
         1. Wait for the download to complete and install the JDK.
     1. Set the JAVA_HOME system environment variable.
 
@@ -98,7 +98,7 @@ Complete the following steps to setup NativeScript on your OS X development mach
            </code></pre>
 
 1. (Optional) Install Genymotion.<br/>Genymotion is a third-party native emulator.
-    1. Go to [Download VirtualBox](https://www.virtualbox.org/wiki/Downloads) and download and install VirtualBox for OS X.
+    1. Go to [Download VirtualBox](https://www.virtualbox.org/wiki/Downloads) and download and install VirtualBox for macOS.
     1. Go to [Get Genymotion](https://www.genymotion.com/#!/download), select Mac and click **Get Genymotion**.
     1. After the download completes, run the installer and complete the installation.
     1. Add the following file paths to the `PATH` system environment variable.

--- a/start/ns-setup-win.md
+++ b/start/ns-setup-win.md
@@ -14,7 +14,7 @@ This page contains a list of all system requirements needed to build and run Nat
 * [System Requirements](#system-requirements)
 * [Advanced Setup Steps](#advanced-setup-steps)
 
-> **NOTE**: On Windows systems you can only use the NativeScript CLI to develop Android apps. This is because the NativeScript CLI uses Xcode to build iOS apps, which is only available on the OS X operating system. If you’re interested in building iOS apps on Windows, you may want to try out the [Telerik Platform](http://www.telerik.com/platform). The Telerik Platform provides robust tooling for NativeScript apps, including a service that performs iOS and Android builds in the cloud, removing the need to complete these system requirements, and allowing you to build for iOS on Windows.
+> **NOTE**: On Windows systems you can only use the NativeScript CLI to develop Android apps. This is because the NativeScript CLI uses Xcode to build iOS apps, which is only available on the macOS operating system. If you’re interested in building iOS apps on Windows, you may want to try out the [Telerik Platform](http://www.telerik.com/platform). The Telerik Platform provides robust tooling for NativeScript apps, including a service that performs iOS and Android builds in the cloud, removing the need to complete these system requirements, and allowing you to build for iOS on Windows.
 
 ## System Requirements
 

--- a/start/quick-setup.md
+++ b/start/quick-setup.md
@@ -12,7 +12,7 @@ With the open-source NativeScript command-line interface and an IDE or text edit
 
 > **NOTE**: The steps on this page are quick setup steps intended for users new to mobile development. If you have existing mobile experience, if you’re on Linux, or if you want full control of the installation process, refer to one of the advanced setup guides below, which walk you through manually setting up your environment for NativeScript development.
 > * [Advanced setup: Windows](/start/ns-setup-win)
-> * [Advanced setup: OS X](/start/ns-setup-os-x)
+> * [Advanced setup: macOS](/start/ns-setup-os-x)
 > * [Advanced setup: Linux](/start/ns-setup-linux)
 
 ## Step 1: Install Node.js
@@ -22,7 +22,7 @@ The NativeScript CLI is built on Node.js, and as such you need to have Node.js i
 You can check whether you have Node.js set up by opening a terminal or command prompt on your development machine and executing `node --version`. If you get an error, head to  <https://nodejs.org/> and download and install the latest “LTS” (long-term support) distribution for your development machine.
 
 > **TIP**:
-> * If you’re on OS X and use [Homebrew](http://brew.sh/), you can alternatively install the Node.js LTS release by running `brew install homebrew/versions/node6-lts` in your terminal.
+> * If you’re on macOS and use [Homebrew](http://brew.sh/), you can alternatively install the Node.js LTS release by running `brew install homebrew/versions/node6-lts` in your terminal.
 > * The NativeScript CLI supports a wide variety of Node.js versions, so if you already have Node.js installed you should be good to go. If, by chance, you’re running an unsupported version, the `tns doctor` command we’ll run momentarily will flag the problem so you can upgrade.
 
 ## Step 2: Install the NativeScript CLI
@@ -33,7 +33,7 @@ Open your terminal or command prompt and execute the following command to instal
 
 > **NOTE**:
 > * You may be asked two questions during the installation—_Do you want to visit the official documentation?_, and _Do you want to run the setup script?_ Go ahead and answer “No” to both questions for now as we’ll cover the documentation and scripts momentarily.
-> * If you’re on OS X and receive an EACCES error, you either need to rerun the previous command with `sudo`—that is, `sudo npm install -g nativescript`—or take a moment to [fix your npm permissions](https://docs.npmjs.com/getting-started/fixing-npm-permissions) so that you don’t need admin rights to globally install npm packages.
+> * If you’re on macOS and receive an EACCES error, you either need to rerun the previous command with `sudo`—that is, `sudo npm install -g nativescript`—or take a moment to [fix your npm permissions](https://docs.npmjs.com/getting-started/fixing-npm-permissions) so that you don’t need admin rights to globally install npm packages.
 
 After completing the setup you should have two commands available from your terminal or command prompt: `tns`—which is short for <b>T</b>elerik <b>N</b>ative<b>S</b>cript—and `nativescript`. The two commands are equivalent, so we'll stick with the shorter `tns`.
 
@@ -51,7 +51,7 @@ $ tns
 
 ## Step 3: Install iOS and Android requirements
 
-When you build with NativeScript you’re building truly native iOS and Android apps, and as such, you need to set up each platform you intend to build for on your development machine. To ease the pain of installing all of these requirements manually, the NativeScript CLI provides quick-start scripts for Windows and OS X that handle the necessary setup for you automatically. Let’s look at how they work.
+When you build with NativeScript you’re building truly native iOS and Android apps, and as such, you need to set up each platform you intend to build for on your development machine. To ease the pain of installing all of these requirements manually, the NativeScript CLI provides quick-start scripts for Windows and macOS that handle the necessary setup for you automatically. Let’s look at how they work.
 
 > **TIP**: Setting up your machine for native development can be tricky, especially if you’re new to mobile development. If you get stuck, or if you have questions while going through these instructions, the NativeScript Community Slack is a great place to get help. Feel free to [join us](http://developer.telerik.com/wp-login.php?action=slack-invitation), and ask any installation questions you may have in the #getting-started channel.
 
@@ -63,15 +63,15 @@ If you’re on Windows, copy and paste the script below into your command prompt
 
 During installation you may need to accept a User Account Control prompt to grant the script administrative privileges. Also, be aware that the script downloads and installs some big dependencies—so it’s common for the script to take a while to complete. When the script finishes, close and reopen your command prompt.
 
-> **NOTE**: On Windows systems you can only use the NativeScript CLI to develop Android apps. This is because the NativeScript CLI uses Xcode to build iOS apps, which is only available on the OS X operating system. If you’re interested in building iOS apps on Windows, you may want to try out the [Telerik Platform](http://www.telerik.com/platform). The Telerik Platform provides robust tooling for NativeScript apps, including a service that performs iOS and Android builds in the cloud, removing the need to complete these system requirements, and allowing you to build for iOS on Windows.
+> **NOTE**: On Windows systems you can only use the NativeScript CLI to develop Android apps. This is because the NativeScript CLI uses Xcode to build iOS apps, which is only available on the macOS operating system. If you’re interested in building iOS apps on Windows, you may want to try out the [Telerik Platform](http://www.telerik.com/platform). The Telerik Platform provides robust tooling for NativeScript apps, including a service that performs iOS and Android builds in the cloud, removing the need to complete these system requirements, and allowing you to build for iOS on Windows.
 
-### OS X
+### macOS
 
 If you’re on a Mac, copy and paste the script below into your terminal and press Enter:
 
 <pre class="add-copy-button"><code class="language-terminal">ruby -e "$(curl -fsSL https://www.nativescript.org/setup/mac)"</code></pre>
 
-Much like the Windows script, the OS X script needs administrative access to run some commands using `sudo`; therefore, you may need to provide your password several times during execution. The OS X script also may take some time to complete, as it’s installing the dependencies for both iOS and Android development. When the script finishes, close and restart your terminal.
+Much like the Windows script, the macOS script needs administrative access to run some commands using `sudo`; therefore, you may need to provide your password several times during execution. The macOS script also may take some time to complete, as it’s installing the dependencies for both iOS and Android development. When the script finishes, close and restart your terminal.
 
 ## Step 4: Verify the setup
 

--- a/start/troubleshooting.md
+++ b/start/troubleshooting.md
@@ -64,7 +64,7 @@ A problem occurred configuring root project 'app_name'.
 
 ### Cannot run or debug apps on iOS 8.1.3 devices with Xcode 6.1
 
-**Problem:** On OS X systems with Xcode 6.1 installed, you cannot run or debug apps on iOS 8.1.3 devices.<br/>The developer disk images provided with the iOS SDK in Xcode 6.1 are not compatible with iOS 8.1.3. The NativeScript CLI uses these disk images to work with your attached iOS devices.
+**Problem:** On macOS systems with Xcode 6.1 installed, you cannot run or debug apps on iOS 8.1.3 devices.<br/>The developer disk images provided with the iOS SDK in Xcode 6.1 are not compatible with iOS 8.1.3. The NativeScript CLI uses these disk images to work with your attached iOS devices.
 
 **Solution:** Update to Xcode 6.1.1 or later.
 
@@ -74,7 +74,7 @@ A problem occurred configuring root project 'app_name'.
 
 **Solution:** Re-run the `debug` command. If you continue to have issue with your Android emulator performance, you may want to consider using a more performant third-party emulator option such as [Genymotion](https://www.genymotion.com/).
 
-### The debug tools for Android never launch on OS X
+### The debug tools for Android never launch on macOS
 
 **Problem:** The NativeScript CLI uses the [opener npm package](https://www.npmjs.com/package/opener) to open Chrome. The current version of the package that the CLI uses cannot open the browser.
 


### PR DESCRIPTION
* Text instances of "OS X" have been changed to "macOS"
* Links were not changed to prevent 404s (i.e. `start/ns-setup-os-x`)
* Historical instances in releases were also not changed

closes #575