### PR TITLE
updated article for debugging

### DIFF
--- a/tooling/debugging.md
+++ b/tooling/debugging.md
@@ -18,6 +18,15 @@ You can debug apps developed with the NativeScript framework from both the Nativ
 
 > **Note** For more details about `Debugger Command` options, you can use `tns debug android --help` or `tns debug ios --help`.
 
+The `debug` command will build and deploy new package on the connected device/emulator.
+It will also track for changes in the `app` folder which mean it will livesync your application
+when changes in your code are saved. On code change & save, the application will be restarted automatically.
+
+The debugging agent won't be started automatically by NativeScript-CLI but will provide a link for the user to open in Google Chrome. The link will appear in the CLI log after the command is executed. Android and iOS have different links, but both can e opened in Google Chrome. When the link is opened, the debugger will be attached.
+
+To enable the same behaviour in iOS, you need to execute `tns debug ios --chrome` (there's a special flag because the default action uses Safari).
+
+
 To start the debugger for Android, run the following command:
 
 ```Bash
@@ -40,6 +49,7 @@ You can customize the `tns debug` command using any of the following options:
 * `--stop` - Detaches the debug tools.
 * `--emulator` - Specifies that you want to debug the app in an emulator.
 * `--timeout` - Sets the number of seconds that the NativeScript CLI will wait for the debugger to boot. If not set, the default timeout is 90 seconds.
+* `--chrome` - iOS specific flag to generate link for debugging with Google Chrome agent (default is Safari)
 
 For more information about Android debugging, run the following command:
 

--- a/tooling/debugging.md
+++ b/tooling/debugging.md
@@ -16,11 +16,11 @@ You can debug apps developed with the NativeScript framework from both the Nativ
 
 ## Debugger Commands
 
-> **Note** For more details about `Debugger Command` options, you can use `tns debug android --help` or `tns debug ios --help`.
-
 The `debug` command builds and deploys new package on the connected device/emulator.
 It also tracks for changes in the `app` folder which mean it will livesync your application
 when changes in your code are saved. On code change & save, the application is restarted automatically.
+
+> **Note** Chagnes inside `App_Resources` folder (e.g. `AndroidManifest.xml`, `info.plist` or any of the resources folders) won't trigger the livesync and the app needs to be rebuild entirely for those to take effect.
 
 The debugging agent won't be started automatically by NativeScript-CLI but a link is provided for the user to open in Google Chrome. The link appears in the CLI log after the command is executed. Android and iOS have different links, but both can be opened in Google Chrome. The debugger is attached once the link is opened.
 
@@ -40,6 +40,8 @@ tns debug ios
 ```
 
 This command starts the platform-specific debugger with the default `--debug-brk` option.
+
+> **Note** For more details about `Debugger Command` options, you can use `tns debug android --help` or `tns debug ios --help`.
 
 ## Debugger Options
 

--- a/tooling/debugging.md
+++ b/tooling/debugging.md
@@ -18,13 +18,13 @@ You can debug apps developed with the NativeScript framework from both the Nativ
 
 > **Note** For more details about `Debugger Command` options, you can use `tns debug android --help` or `tns debug ios --help`.
 
-The `debug` command will build and deploy new package on the connected device/emulator.
-It will also track for changes in the `app` folder which mean it will livesync your application
-when changes in your code are saved. On code change & save, the application will be restarted automatically.
+The `debug` command builds and deploys new package on the connected device/emulator.
+It also tracks for changes in the `app` folder which mean it will livesync your application
+when changes in your code are saved. On code change & save, the application is restarted automatically.
 
-The debugging agent won't be started automatically by NativeScript-CLI but will provide a link for the user to open in Google Chrome. The link will appear in the CLI log after the command is executed. Android and iOS have different links, but both can e opened in Google Chrome. When the link is opened, the debugger will be attached.
+The debugging agent won't be started automatically by NativeScript-CLI but a link is provided for the user to open in Google Chrome. The link appears in the CLI log after the command is executed. Android and iOS have different links, but both can be opened in Google Chrome. The debugger is attached once the link is opened.
 
-To enable the same behaviour in iOS, you need to execute `tns debug ios --chrome` (there's a special flag because the default action uses Safari).
+To enable the same behaviour in iOS, the command `tns debug ios --chrome` needs to be execured (there's a special flag because the default action uses Safari as debug agent).
 
 
 To start the debugger for Android, run the following command:


### PR DESCRIPTION
Debug now (2.5.x+) will act like livesync with --watch. Debugger not started by CLI, but a link is generated in the logs. Any saved changes will trigger application restart. Flag --chrome added for iOS debugger to create link fro Chrome.