### PR TITLE
article for publishing for iOS updated (when using tns prepare)

### DIFF
--- a/publishing/publishing-ios-apps.md
+++ b/publishing/publishing-ios-apps.md
@@ -40,7 +40,7 @@ You can publish a NativeScript app in the *App Store* the same way you would [re
 
  1. Verify that the iOS native project inside your app contains your latest changes and resources by running the following command.
      ```
-     tns prepare ios
+     tns prepare ios --release
      ```
  2. Open the iOS native project in Xcode. Your native project is located at: `{app-name}/platforms/ios/{app-name}.xcodeproj`.
  3. [Configure the project for distribution](https://developer.apple.com/library/ios/documentation/IDEs/Conceptual/AppDistributionGuide/ConfiguringYourApp/ConfiguringYourApp.html).


### PR DESCRIPTION
since N 2.3 the prepare command no longer produces both debug and release IPAs so now the proper command for this section of the article should include `--prepare`