### PR TITLE
changed from nodejs to nodejs-lts package

### DIFF
--- a/start/ns-setup-win.md
+++ b/start/ns-setup-win.md
@@ -48,7 +48,7 @@ Complete the following steps to set up NativeScript on your Windows development 
 
     - In the command prompt, run the following command.
 
-        <pre class="add-copy-button"><code class="language-terminal">choco install nodejs -y -version 6.9.1
+        <pre class="add-copy-button"><code class="language-terminal">choco install nodejs-lts -y
         </code></pre>
 
 3. Install [JDK 8](http://www.oracle.com/technetwork/java/javase/downloads/index.html) or a later stable official release.


### PR DESCRIPTION
There is now a Chocolatey package for the LTS version of node called [nodejs-lts](http://chocolatey.org/packages/nodejs-lts)