### PR TITLE
Hide multiple-screens article for angular

### DIFF
--- a/ui/supporting-multiple-screens.md
+++ b/ui/supporting-multiple-screens.md
@@ -4,6 +4,7 @@ description: Learn how to tailor you application for different screen sizes.
 position: 150
 slug: multiple-screen-sizes
 previous_url: /core-concepts/supporting-multiple-screens
+environment: nativescript
 ---
 
 # Supporting Multiple Screens


### PR DESCRIPTION
Multiple screens  with extensions is not supported for angular - better hide the article.