### PR TITLE
Ch3: Fixed missing NativeScriptHttpModule import

### DIFF
--- a/tutorial/ng-chapter-3.md
+++ b/tutorial/ng-chapter-3.md
@@ -119,13 +119,15 @@ Next, open `app/app.module.ts` and replaces its contents with the code below, wh
 import { NgModule } from "@angular/core";
 import { NativeScriptFormsModule } from "nativescript-angular/forms";
 import { NativeScriptModule } from "nativescript-angular/nativescript.module";
+import { NativeScriptHttpModule } from "nativescript-angular";
 
 import { AppComponent } from "./app.component";
 
 @NgModule({
   imports: [
     NativeScriptModule,
-    NativeScriptFormsModule
+    NativeScriptFormsModule,
+    NativeScriptHttpModule
   ],
   declarations: [AppComponent],
   bootstrap: [AppComponent]


### PR DESCRIPTION
The tutorial breaks after adding the http post request in section 3.4 Services. This is fixed by importing NativeScriptHttpModule into app.module.ts