### PR TITLE
Linux installation docs update

### DIFF
--- a/start/ns-setup-linux.md
+++ b/start/ns-setup-linux.md
@@ -85,6 +85,9 @@ Complete the following steps to set up NativeScript on your Linux development ma
     </code></pre>
 
 1. Setup Android Emulators (AVD) by following the article [here]({%slug android-emulators%})
+    1. After creating an emulated device you need to:
+        * Enable its Developer mode - go to _Settings -> About emulated device_ and tap 7 times on _Build number_
+        * Enable USB debugging - go to _Settings -> Developer options_ and enable USB Debugging 
 
 1. Install the NativeScript CLI.
     1. Run the following command.


### PR DESCRIPTION
Proposing to add an extra step in the Linux installation step - to enable the Developer mode + USB debugging on the emulated device. Without this step `tns run android` was failing with ```Cannot run your app in the native emulator. Increase the timeout of the operation with the --timeout option or try to restart your adb server with 'adb kill-server' command. Alternatively, run the Android Virtual Device manager and increase the allocated RAM for the virtual device."```

Enabling the developer mode + USB debugging solved the issue on both Windows and Linux for me.