### PR TITLE
Fix two links to other docs pages

### DIFF
--- a/docs/tutorial/chapter-2.md
+++ b/docs/tutorial/chapter-2.md
@@ -193,7 +193,7 @@ After your app updates with this change, you may expect to see a polished login 
 
 Currently you only see a single button because you need to tell NativeScript how to layout your page’s UI components. Let's look at how to use NativeScript layouts to arrange these components on the screen.
 
-> **TIP**: The NativeScript docs include a [full list of the UI components and attributes](/ui-with-xml) with which you can build your apps. You can even [build your own, custom UI components](/ui-with-xml#custom-components).
+> **TIP**: The NativeScript docs include a [full list of the UI components and attributes](/ui/components) with which you can build your apps. You can even [build your own, custom UI components](/ui/basics#custom-components).
 
 ## 2.4: Layouts 
 


### PR DESCRIPTION
These two links point to the top-level page http://docs.nativescript.org/ui/basics#user-interface-components instead of the specific sections they describe.

This change makes the links point to specific sections - the list of components, and the custom components section.