### PR TITLE
Update testing.md with tips about including reflect-metadata

### DIFF
--- a/docs/tooling/testing.md
+++ b/docs/tooling/testing.md
@@ -103,10 +103,7 @@ describe("Hello World Sample Test:", function() {
 // (Angular w/TypeScript)
 // As our intention is to test an Angular component that contains annotations 
 // we need to include the reflect-metadata dependency.
-import * as reflect from "reflect-metadata"; 
-// The reason we assign it to r is that the Nativescript compiler does not include
-// the import in the compiled JS unless it is actually used in the file.
-const r=reflect;
+import "reflect-metadata"; 
 
 // A sample Jasmine test
 describe("A suite", function() {

--- a/docs/tooling/testing.md
+++ b/docs/tooling/testing.md
@@ -99,10 +99,14 @@ describe("Hello World Sample Test:", function() {
   });
 });
 ```
-```Jasmine (Angular w/TypeScript)
+```Jasmine 
+// (Angular w/TypeScript)
 // As our intention is to test an Angular component that contains annotations 
 // we need to include the reflect-metadata dependency.
-import * as reflect from "reflect-metadata";
+import * as reflect from "reflect-metadata"; 
+// The reason we assign it to r is that the Nativescript compiler does not include
+// the import in the compiled JS unless it is actually used in the file.
+const r=reflect;
 
 // A sample Jasmine test
 describe("A suite", function() {


### PR DESCRIPTION
Updated the comment about importing reflect-metadata to include an assignment to ensure that the compiled JS actually has the import.  Also, tidied up that original comment so that it will render properly in MD.