### PR TITLE
Include returnPress in Chapter 4 #groceryTextField

### DIFF
--- a/docs/tutorial/ng-chapter-4.md
+++ b/docs/tutorial/ng-chapter-4.md
@@ -446,7 +446,7 @@ Now that we have the UI ready, let’s make the add button work.
 Open `app/pages/list/list.html` and give the existing `<TextField>` a new `[(ngModel)]` attribute so that it looks like this:
 
 ``` XML
-<TextField #groceryTextField [(ngModel)]="grocery" hint="Enter a grocery item" (returnPress)="add()" "col="0"></TextField>
+<TextField #groceryTextField [(ngModel)]="grocery" hint="Enter a grocery item" (returnPress)="add()" col="0"></TextField>
 ```
 
 Note our new use of the `(returnPress)` binding. This will fire the `add()` method when the user hits return.

--- a/docs/tutorial/ng-chapter-4.md
+++ b/docs/tutorial/ng-chapter-4.md
@@ -446,7 +446,7 @@ Now that we have the UI ready, let’s make the add button work.
 Open `app/pages/list/list.html` and give the existing `<TextField>` a new `[(ngModel)]` attribute so that it looks like this:
 
 ``` XML
-<TextField #groceryTextField [(ngModel)]="grocery" hint="Enter a grocery item" (returnPress)="add() "col="0"></TextField>
+<TextField #groceryTextField [(ngModel)]="grocery" hint="Enter a grocery item" (returnPress)="add()" "col="0"></TextField>
 ```
 
 Note our new use of the `(returnPress)` binding. This will fire the `add()` method when the user hits return.

--- a/docs/tutorial/ng-chapter-4.md
+++ b/docs/tutorial/ng-chapter-4.md
@@ -446,8 +446,10 @@ Now that we have the UI ready, let’s make the add button work.
 Open `app/pages/list/list.html` and give the existing `<TextField>` a new `[(ngModel)]` attribute so that it looks like this:
 
 ``` XML
-<TextField #groceryTextField [(ngModel)]="grocery" hint="Enter a grocery item" col="0"></TextField>
+<TextField #groceryTextField [(ngModel)]="grocery" hint="Enter a grocery item" (returnPress)="add() "col="0"></TextField>
 ```
+
+Note our new use of the `(returnPress)` binding. This will fire the `add()` method when the user hits return.
 
 Next, add a new `tap` event binding to the image, so that the full `<Image>` looks like this:
 


### PR DESCRIPTION
Hitting the add button can be a bit cumbersome.  Seems like a prime chance to teach people how to use returnPress.