### PR TITLE
let JDK 8 link lead to jdk 8 not to latest java

### DIFF
--- a/docs/start/ns-setup-linux.md
+++ b/docs/start/ns-setup-linux.md
@@ -51,7 +51,7 @@ Complete the following steps to set up NativeScript on your Linux development ma
     <pre class="add-copy-button"><code class="language-terminal">sudo apt-get install g++
     </code></pre>
 
-1. Install [JDK 8](http://www.oracle.com/technetwork/java/javase/downloads/index.html).
+1. Install [JDK 8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html).
     1. Run the following commands.
 
         <pre class="add-copy-button"><code class="language-terminal">sudo apt-get install python-software-properties


### PR DESCRIPTION
currently nativescript android doesn't work with java 9, so let's change the link to point to the real JDK 8 download page