### PR TITLE
snippets using moduleId to resolve relative paths (WebPack related)

### DIFF
--- a/docs/tutorial/ng-chapter-3.md
+++ b/docs/tutorial/ng-chapter-3.md
@@ -264,7 +264,8 @@ As one final change, because this template is getting to be a bit complex, letâ€
 Finally, in `app/app.component.ts`, replace the existing `template` property with the new `templateUrl` property shown below:
 
 ``` TypeScript
-templateUrl: "pages/login/login.html"
+moduleId: module.id,
+templateUrl: "./login.html"
 ```
 
 In case you got lost during this section, hereâ€™s a copy-and-paste friendly of the `app/app.component.ts` file you should have at this point:
@@ -276,8 +277,9 @@ import { User } from "./shared/user/user";
 
 @Component({
   selector: "my-app",
-  templateUrl: "pages/login/login.html",
-  styleUrls: ["pages/login/login-common.css", "pages/login/login.css"]
+  moduleId: module.id,
+  templateUrl: "./login.html",
+  styleUrls: ["./login-common.css", "./login.css"]
 })
 export class AppComponent {
   user: User;
@@ -344,8 +346,9 @@ After that, add a new `providers` property to the existing `@Component` decorato
 @Component({
   selector: "my-app",
   providers: [UserService],
-  templateUrl: "pages/login/login.html",
-  styleUrls: ["pages/login/login-common.css", "pages/login/login.css"],
+  moduleId: module.id,
+  templateUrl: "./login.html",
+  styleUrls: ["./login-common.css", "./login.css"],
 })
 ```
 
@@ -649,8 +652,9 @@ import { Component } from "@angular/core";
 
 @Component({
   selector: "list",
-  templateUrl: "pages/list/list.html",
-  styleUrls: ["pages/list/list-common.css", "pages/list/list.css"]
+  moduleId: module.id,
+  templateUrl: "./list.html",
+  styleUrls: ["./list-common.css", "./list.css"]
 })
 export class ListComponent {}
 ```

--- a/docs/tutorial/ng-chapter-4.md
+++ b/docs/tutorial/ng-chapter-4.md
@@ -207,8 +207,9 @@ import { Component, ElementRef, OnInit, ViewChild } from "@angular/core";
 
 @Component({
   selector: "list",
-  templateUrl: "pages/list/list.html",
-  styleUrls: ["pages/list/list-common.css", "pages/list/list.css"]
+  moduleId: module.id,
+  templateUrl: "./list.html",
+  styleUrls: ["./list-common.css", "./list.css"]
 })
 export class ListComponent implements OnInit {
   groceryList: Array<Object> = [];
@@ -322,8 +323,9 @@ Next, because you’re injecting a service into your constructor you must also i
 ``` TypeScript
 @Component({
   selector: "list",
-  templateUrl: "pages/list/list.html",
-  styleUrls: ["pages/list/list-common.css", "pages/list/list.css"],
+  moduleId: module.id,
+  templateUrl: "./list.html",
+  styleUrls: ["./list-common.css", "./list.css"],
   providers: [GroceryListService]
 })
 ```
@@ -351,8 +353,9 @@ import { GroceryListService } from "../../shared/grocery/grocery-list.service";
 
 @Component({
   selector: "list",
-  templateUrl: "pages/list/list.html",
-  styleUrls: ["pages/list/list-common.css", "pages/list/list.css"],
+  moduleId: module.id,
+  templateUrl: "./list.html",
+  styleUrls: ["./list-common.css", "./list.css"],
   providers: [GroceryListService]
 })
 export class ListComponent implements OnInit {


### PR DESCRIPTION
Related to [https://github.com/NativeScript/docs/issues/937](https://github.com/NativeScript/docs/issues/937)

Using `moduleiD : module.id` provides relative paths and also allows bundling with WebPack

@tjvantoll should we revise the source code in sample-Groceries as well? 
Let me know if you have some considerations against it.