### PR TITLE
improvements to quick setup doc

### DIFF
--- a/docs/start/quick-setup.md
+++ b/docs/start/quick-setup.md
@@ -10,6 +10,7 @@ previous_url: /setup/quick-setup
 
 With the open-source NativeScript command-line interface and an IDE or text editor of your choice, you can create, develop, store, and build your apps locally, free of charge and anonymously. Let’s look at how to set up the CLI for development.
 
+> **TIP**: Try [NativeScript Sidekick](https://www.nativescript.org/nativescript-sidekick) for a one-click setup experience for macOS, Windows, and Linux. Sidekick installs the NativeScript CLI and dependencies listed below - and offers starter kits, cloud-based builds for iOS and Android, and app store publishing.
 
 ## Step 1: Install Node.js
 

--- a/docs/start/quick-setup.md
+++ b/docs/start/quick-setup.md
@@ -69,7 +69,7 @@ Please be sure that you run this command in cmd as an administator (Windows key 
 
 During installation you may need to accept a User Account Control prompt to grant the script administrative privileges. Also, be aware that the script downloads and installs some big dependencies—so it’s common for the script to take a while to complete. When the script finishes, close and reopen your command prompt.
 
-> **NOTE**: On Windows systems you can only use the NativeScript CLI to develop Android apps. This is because the NativeScript CLI uses Xcode to build iOS apps, which is only available on macOS. If you’re interested in building iOS apps on Windows, you should download [NativeScript Sidekick](https://www.nativescript.org/nativescript-sidekick).
+> **NOTE**: On Windows and Linux systems you can only use the NativeScript CLI to develop Android apps. This is because the NativeScript CLI uses Xcode to build iOS apps, which is only available on macOS. If you’re interested in building iOS apps on Windows or Linux, you should download [NativeScript Sidekick](https://www.nativescript.org/nativescript-sidekick).
 
 ### macOS
 

--- a/docs/start/quick-setup.md
+++ b/docs/start/quick-setup.md
@@ -10,7 +10,9 @@ previous_url: /setup/quick-setup
 
 With the open-source NativeScript command-line interface and an IDE or text editor of your choice, you can create, develop, store, and build your apps locally, free of charge and anonymously. Let’s look at how to set up the CLI for development.
 
+<!--
 > **TIP**: Try [NativeScript Sidekick](https://www.nativescript.org/nativescript-sidekick) for a one-click setup experience for macOS, Windows, and Linux. Sidekick installs the NativeScript CLI and dependencies listed below - and offers starter kits, cloud-based builds for iOS and Android, and app store publishing.
+-->
 
 ## Step 1: Install Node.js
 

--- a/docs/start/quick-setup.md
+++ b/docs/start/quick-setup.md
@@ -8,23 +8,24 @@ previous_url: /setup/quick-setup
 
 # Set Up Your System
 
-With the open-source NativeScript command-line interface and an IDE or text editor of your choice, you can create, develop, store and build your apps entirely locally, free of charge and anonymously. Let’s look at how to set up the CLI for development.
+With the open-source NativeScript command-line interface and an IDE or text editor of your choice, you can create, develop, store, and build your apps locally, free of charge and anonymously. Let’s look at how to set up the CLI for development.
+
 
 ## Step 1: Install Node.js
 
 The NativeScript CLI is built on Node.js, and as such you need to have Node.js installed to use NativeScript.
 
-You can check whether you have Node.js set up by opening a terminal or command prompt on your development machine and executing `node --version`. If you get an error, head to  <https://nodejs.org/> and download and install the latest “LTS” (long-term support) distribution for your development machine.
+You can check whether you have Node.js set up by opening a terminal or command prompt and executing `node --version`. If you get an error, head to  <https://nodejs.org/> and download and install the latest “LTS” (long-term support) distribution and restart your terminal or command prompt.
 
 > **TIP**:
-> * If you’re on macOS and use [Homebrew](http://brew.sh/), you can alternatively install the Node.js LTS release by running `brew update`, to download the latest available updates and then `brew install node@6` in your terminal.
+> * If you’re on macOS and use [Homebrew](http://brew.sh/), you can alternatively install the Node.js LTS release by running `brew update` (to download the latest updates) and then `brew install node@6` in your terminal.
 > * The NativeScript CLI supports a wide variety of Node.js versions, so if you already have Node.js installed you should be good to go. If, by chance, you’re running an unsupported version, the `tns doctor` command we’ll run momentarily will flag the problem so you can upgrade.
 
-> **NOTE**: Bear in mind that you should add the path to `node@6/bin` manually by running `echo 'export PATH="/usr/local/opt/node@6/bin:$PATH"' >> ~/.bash_profile` in your terminal.
+> **NOTE**: Mac users, bear in mind that you should add the path to `node@6/bin` manually by running `echo 'export PATH="/usr/local/opt/node@6/bin:$PATH"' >> ~/.bash_profile` and restart your terminal.
 
 ## Step 2: Install the NativeScript CLI
 
-Open your terminal or command prompt and execute the following command to install the NativeScript CLI from npm, which is Node.js’ package manager:
+Open your terminal or command prompt and execute the following command to install the NativeScript CLI from npm, which is the Node.js package manager:
 
 <pre class="add-copy-button"><code class="language-terminal">npm install -g nativescript</code></pre>
 
@@ -34,7 +35,7 @@ Open your terminal or command prompt and execute the following command to instal
 
 After completing the setup you should have two commands available from your terminal or command prompt: `tns`—which is short for <b>T</b>elerik <b>N</b>ative<b>S</b>cript—and `nativescript`. The two commands are equivalent, so we'll stick with the shorter `tns`.
 
-You can verify the installation was successful by running `tns` in your terminal. You should see something like this:
+You can verify the installation was successful by running `tns` in your terminal. You should see a long list of commands that starts with this section:
 
 ```
 $ tns
@@ -48,10 +49,10 @@ $ tns
 
 ## Step 3: Install iOS and Android requirements
 
-When you build with NativeScript you’re building truly native iOS and Android apps, and as such, you need to set up each platform you intend to build for on your development machine. To ease the pain of installing all of these requirements manually, the NativeScript CLI provides quick-start scripts for Windows and macOS that handle the necessary setup for you automatically. Let’s look at how they work.
+When you build with NativeScript you’re building truly native iOS and Android apps, and as such, you need to set up each platform you intend to build for on your development machine. To ease the pain of installing all of these requirements manually, the NativeScript CLI provides quick-start scripts for Windows and macOS. Let’s look at how they work.
 
 > **TIP**:
-> * Setting up your machine for native development can be tricky, especially if you’re new to mobile development. If you get stuck, or if you have questions while going through these instructions, the [NativeScript community forum](http://forum.nativescript.org/) is a great place to get help.
+> * Setting up your machine for native development can be tricky, especially if you’re new to mobile development. If you get stuck, or if you have questions while going through these instructions, the [NativeScript community forum](https://discourse.nativescript.org/c/getting-started) is a great place to get help.
 > * If you’re not comfortable with a script automatically installing dependencies on your development machine, or if you’re on Linux, refer to one of the advanced setup guides below for details on manually installing NativeScript’s iOS and Android dependencies.
 >     * [Advanced setup: Windows](/start/ns-setup-win)
 >     * [Advanced setup: macOS](/start/ns-setup-os-x)
@@ -61,13 +62,13 @@ When you build with NativeScript you’re building truly native iOS and Android 
 
 If you’re on Windows, copy and paste the script below into your command prompt as an administrator and press Enter:
 
-Please be sure that you run this command in cmd as an administator (Windows key > type "cmd" > right click > Run as Administrator ).
+Please be sure that you run this command in cmd as an administator (Windows key > type "cmd" > right click > Run as Administrator).
 
 <pre class="add-copy-button"><code class="language-terminal">@powershell -NoProfile -ExecutionPolicy Bypass -Command "iex ((new-object net.webclient).DownloadString('https://www.nativescript.org/setup/win'))"</code></pre>
 
 During installation you may need to accept a User Account Control prompt to grant the script administrative privileges. Also, be aware that the script downloads and installs some big dependencies—so it’s common for the script to take a while to complete. When the script finishes, close and reopen your command prompt.
 
-> **NOTE**: On Windows systems you can only use the NativeScript CLI to develop Android apps. This is because the NativeScript CLI uses Xcode to build iOS apps, which is only available on the macOS operating system. If you’re interested in building iOS apps on Windows, you may want to try out the public preview of [NativeScript Sidekick](https://www.nativescript.org/nativescript-sidekick). NativeScript Sidekick provides robust tooling for NativeScript apps, including a service that performs iOS and Android builds in the cloud, removing the need to complete these system requirements, and allowing you to build for iOS on Windows.
+> **NOTE**: On Windows systems you can only use the NativeScript CLI to develop Android apps. This is because the NativeScript CLI uses Xcode to build iOS apps, which is only available on macOS. If you’re interested in building iOS apps on Windows, you should download [NativeScript Sidekick](https://www.nativescript.org/nativescript-sidekick).
 
 ### macOS
 
@@ -75,7 +76,7 @@ If you’re on a Mac, copy and paste the script below into your terminal and pre
 
 <pre class="add-copy-button"><code class="language-terminal">ruby -e "$(curl -fsSL https://www.nativescript.org/setup/mac)"</code></pre>
 
-Much like the Windows script, the macOS script needs administrative access to run some commands using `sudo`; therefore, you may need to provide your password several times during execution. The macOS script also may take some time to complete, as it’s installing the dependencies for both iOS and Android development. When the script finishes, close and restart your terminal.
+The macOS script needs administrative access to run some commands using `sudo`; therefore, you may need to provide your password several times during execution. The macOS script also may take some time to complete, as it’s installing the dependencies for both iOS and Android development. When the script finishes, close and restart your terminal.
 
 ## Step 4: Verify the setup
 


### PR DESCRIPTION
Cleaned up the "quick setup" instructions for grammar, clarified sentences/instructions, and made Sidekick a more prominent part of the guide. NOTE: should not be merged until after the next Sidekick release (after the 3.4 release)