### PR TITLE
refactor: Update theme installation instructions

### DIFF
--- a/docs/ui/theme.md
+++ b/docs/ui/theme.md
@@ -55,14 +55,14 @@ The NativeScript core theme includes two standard color schemes, light and dark.
 To use the light color scheme, add the following line of code to the top of your `app.css` file:
 
 ``` CSS
-@import '~/nativescript-theme-core/css/core.light.css';
+@import '~nativescript-theme-core/css/core.light.css';
 ```
 
 And in order to use the dark scheme, add this line of code to your `app.css` instead:
 
 
 ``` CSS
-@import '~/nativescript-theme-core/css/core.dark.css';
+@import '~nativescript-theme-core/css/core.dark.css';
 ```
 
 > **TIP**: When using the dark color scheme, make sure that you, 1) apply the [`page` class name](#page) to ensure your app’s text displays appropriately, and 2) [alter your app’s status bar colors](#status-bar-considerations).
@@ -70,17 +70,17 @@ And in order to use the dark scheme, add this line of code to your `app.css` ins
 You may want to alternatively use one of the 11 other color schemes included in the NativeScript core theme. To do so, switch your `app.css` file to use one of the following imports.
 
 ``` CSS
-@import '~/nativescript-theme-core/css/aqua.css';
-@import '~/nativescript-theme-core/css/blue.css';
-@import '~/nativescript-theme-core/css/brown.css';
-@import '~/nativescript-theme-core/css/forest.css';
-@import '~/nativescript-theme-core/css/grey.css';
-@import '~/nativescript-theme-core/css/lemon.css';
-@import '~/nativescript-theme-core/css/lime.css';
-@import '~/nativescript-theme-core/css/orange.css';
-@import '~/nativescript-theme-core/css/purple.css';
-@import '~/nativescript-theme-core/css/ruby.css';
-@import '~/nativescript-theme-core/css/sky.css';
+@import '~nativescript-theme-core/css/aqua.css';
+@import '~nativescript-theme-core/css/blue.css';
+@import '~nativescript-theme-core/css/brown.css';
+@import '~nativescript-theme-core/css/forest.css';
+@import '~nativescript-theme-core/css/grey.css';
+@import '~nativescript-theme-core/css/lemon.css';
+@import '~nativescript-theme-core/css/lime.css';
+@import '~nativescript-theme-core/css/orange.css';
+@import '~nativescript-theme-core/css/purple.css';
+@import '~nativescript-theme-core/css/ruby.css';
+@import '~nativescript-theme-core/css/sky.css';
 ```
 
 > **TIP**: [This image](/img/theme/color-schemes-all.png) shows all 13 color schemes on iOS and Android, and can help you decide which color scheme is a good fit for your app.


### PR DESCRIPTION
The main theme imports are now handled only with **tilde** (instead of tilde-slash)
For example:
the newly introduced import syntax
```
@import '~nativescript-theme-core/css/core.dark.css';
```

the old way was
```
@import '~/nativescript-theme-core/css/core.dark.css';
```