### PR TITLE
Updated native iOS component for HtmlView

### DIFF
--- a/docs/ui/components.md
+++ b/docs/ui/components.md
@@ -187,7 +187,7 @@ The {% nativescript %}[HtmlView]({%ns_cookbook ui/html-view%}){% endnativescript
 
 | Android                | iOS      |
 |:-----------------------|:---------|
-| [android.widget.TextView](http://developer.android.com/reference/android/widget/TextView.html) | [UILabel](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UILabel_Class/) |
+| [android.widget.TextView](http://developer.android.com/reference/android/widget/TextView.html) | [UITextView](https://developer.apple.com/documentation/uikit/uitextview) |
 
 ## WebView
 


### PR DESCRIPTION
See https://github.com/NativeScript/NativeScript/blob/master/tns-core-modules/ui/html-view/html-view.d.ts#L22 and https://github.com/NativeScript/NativeScript/blob/master/tns-core-modules/ui/html-view/html-view.ios.ts#L12 Widget actually uses UITextView and not UILabel