### PR TITLE
Update ActionBar's padding-top css property

### DIFF
--- a/docs/tutorial/ng-chapter-6.md
+++ b/docs/tutorial/ng-chapter-6.md
@@ -215,7 +215,7 @@ On Android a translucent status bar does not take up space, so you need to add a
 
 ``` CSS
 ActionBar {
-  padding-top: 10;
+  padding-top: 24;
 }
 ```
 


### PR DESCRIPTION
Update ActionBar's padding-top css property from 10 to 24 units,
Source:
[Material guidelines: Metrics and keylines](https://material.io/guidelines/layout/metrics-keylines.html#metrics-keylines-keylines-spacing)