### PR TITLE
Navigation Transitions: fix object context for custom transitions

### DIFF
--- a/docs/core-concepts/navigation.md
+++ b/docs/core-concepts/navigation.md
@@ -495,7 +495,7 @@ const CustomTransition = (function (_super) {
     function CustomTransition() {
         _super.apply(this, arguments);
     }
-    CustomTransition.prototype.createAndroidAnimator = (transitionType) => {
+    CustomTransition.prototype.createAndroidAnimator = function(transitionType) {
         const scaleValues = java.lang.reflect.Array.newInstance(floatType, 2);
         switch (transitionType) {
             case transition.AndroidTransitionType.enter:
@@ -568,7 +568,7 @@ const CustomTransition = (function (_super) {
     function CustomTransition() {
         _super.apply(this, arguments);
     }
-    CustomTransition.prototype.animateIOSTransition = (containerView, fromView, toView, operation, completion) => {
+    CustomTransition.prototype.animateIOSTransition = function(containerView, fromView, toView, operation, completion) {
         toView.transform = CGAffineTransformMakeScale(0, 0);
         fromView.transform = CGAffineTransformIdentity;
         switch (operation) {


### PR DESCRIPTION
The use of arrow functions for the `createAndroidAnimator ` and `animateIOSTransition ` callbacks prevented binding of the scope which is needed for `getDuration` and `getCurve` functions.
I have changed the callbacks to use normal functions instead in the examples to avoid this.