### PR TITLE
docs(dialogs.md): add missing inputType for prompt

### DIFF
--- a/docs/ui/dialogs.md
+++ b/docs/ui/dialogs.md
@@ -142,7 +142,7 @@ dialogs.prompt("Your message", "Default text").then(r => {
 
 ```JavaScript
 var dialogs = require("ui/dialogs");
-// inputType property can be dialogs.inputType.password or dialogs.inputType.text.
+// inputType property can be dialogs.inputType.password, dialogs.inputType.text, or dialogs.inputType.email.
 dialogs.prompt({
     title: "Your title",
     message: "Your message",
@@ -157,7 +157,7 @@ dialogs.prompt({
 ```
 ```TypeScript
 import * as dialogs from "ui/dialogs";
-// inputType property can be dialogs.inputType.password or dialogs.inputType.text.
+// inputType property can be dialogs.inputType.password, dialogs.inputType.text, or dialogs.inputType.email.
 dialogs.prompt({
     title: "Your title",
     message: "Your message",


### PR DESCRIPTION
As per https://github.com/NativeScript/NativeScript/blob/master/tns-core-modules/ui/dialogs/dialogs-common.ts#L18 prompt also accepts email as input type.

## PR Checklist

- [x ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.

## What is the current state of the documentation article?
Article doesn't mention input type "email".

## What is the new state of the documentation article?
Article mentions additional value for input type: email.

