### PR TITLE
refactor: Android metadata section

### DIFF
--- a/docs/runtimes/android/requirements.md
+++ b/docs/runtimes/android/requirements.md
@@ -16,11 +16,8 @@ The Android Runtime is built against [API level 17](http://developer.android.com
 ## Supported Application Binary Interfaces (ABI)
 Currently supported are the following CPU instruction sets:
 
-## armeabi-v7a
-This is an ARM-based CPU instruction set that extends the standard ARM one and adds support for hardware floating-point support and multiple CPU cores.
+- **armeabi-v7a** - This is an ARM-based CPU instruction set that extends the standard ARM one and adds support for hardware floating-point support and multiple CPU cores.
 
-## x86
-This is an Application Binary Interface (ABI) that supports the instruction set commonly named *x86* or *IA-32*.
+- **x86** - This is an Application Binary Interface (ABI) that supports the instruction set commonly named *x86* or *IA-32*.
 
-## x64
-This is the 64-bit version of the *x86* instruction set. It supports larger amounts of virtual and physical memory than it was possible on its predecessor. It is backward compatible with 32-bit *x86* code
+- **x64** - This is the 64-bit version of the *x86* instruction set. It supports larger amounts of virtual and physical memory than it was possible on its predecessor. It is backward compatible with 32-bit *x86* code

--- a/docs/runtimes/android/requirements.md
+++ b/docs/runtimes/android/requirements.md
@@ -9,9 +9,9 @@ position: 2
 The recommended ways to create NativeScript Applications is either through the [Command-Line Interface (CLI)](https://github.com/NativeScript/nativescript-cli) or through the [NativeScript Sidekick](https://www.nativescript.org/nativescript-sidekick).
 
 # Supported API Levels
-The Android Runtime is built against [API level 17](http://developer.android.com/about/versions/android-4.2.html). The minimum supported compile SDK version is 22. Additionally, using the [metadata-generator](metadata/generator.md) tool you may generate your own metadata for any Android SDK available in the Android SDK Manager.
+The Android Runtime is built against [API level 17](http://developer.android.com/about/versions/android-4.2.html). The minimum supported compile SDK version is 22. For all supported API levels the metadata is created (mappings between JavaScript and Java/Android worlds). Detailed information about the NativeScript metadata can be found in the [Metadata Overview article](metadata/overview.md).
 
-> **Note:** You may not use APIs that are not present in the generated metadata from JavaScript. Still, you may build your application using higher API level given your code is compatible with the metadata API level.
+> **Note:** You can not use APIs that are not present in the generated metadata from JavaScript. Still, you may build your application using higher API level given your code is compatible with the metadata API level.
 
 # Supported Application Binary Interfaces (ABI)
 Currently supported are the following CPU instruction sets:

--- a/docs/runtimes/android/requirements.md
+++ b/docs/runtimes/android/requirements.md
@@ -8,12 +8,12 @@ position: 2
 # System Requirements
 The recommended ways to create NativeScript Applications is either through the [Command-Line Interface (CLI)](https://github.com/NativeScript/nativescript-cli) or through the [NativeScript Sidekick](https://www.nativescript.org/nativescript-sidekick).
 
-# Supported API Levels
+## Supported API Levels
 The Android Runtime is built against [API level 17](http://developer.android.com/about/versions/android-4.2.html). The minimum supported compile SDK version is 22. For all supported API levels the metadata is created (mappings between JavaScript and Java/Android worlds). Detailed information about the NativeScript metadata can be found in the [Metadata Overview article](metadata/overview.md).
 
 > **Note:** You can not use APIs that are not present in the generated metadata from JavaScript. Still, you may build your application using higher API level given your code is compatible with the metadata API level.
 
-# Supported Application Binary Interfaces (ABI)
+## Supported Application Binary Interfaces (ABI)
 Currently supported are the following CPU instruction sets:
 
 ## armeabi-v7a

--- a/docs/runtimes/require.md
+++ b/docs/runtimes/require.md
@@ -9,6 +9,8 @@ position: 0
 
 NativeScript modules and the code for your NativeScript app need to comply with the [CommonJS specification](http://wiki.commonjs.org/wiki/Modules/1.1.1). In NativeScript, files and modules are in one-to-one correspondence. To be able to call the functionality of a custom or built-in NativeScript module, you need to reference it in a `require` statement. When declaring your `require` statements, keep in mind that the NativeScript runtimes search and evaluate JavaScript files in a platform-dependent way for performance reasons.
 
+> **Note:** The good development practice for Angular and TypeScript based applicaitons is to use ES6 specification (e.g. `import` and `export`). In NativeScript all TypeScript files will be downcompiled to ES5 and the generated files will be transpiled according to the CommonJS specification (`require` and `module.exports`).
+
 This is the typical architecture of a built and packaged NativeScript app. All example `require` statements in this article refer to this sample architecture:
 ```
 /private/var/.../Applications/HelloWorldApp.app
@@ -35,7 +37,7 @@ There are several ways you can load CommonJS modules:
 ### Loading Absolute Files
 Paths starting with `/` are treated as absolute paths relative to the device file system:
 
-```javascript
+```JavaScript
 require('/private/.../HelloWorldApp.app/app/app.js');
 ```
 Resolves to `/private/.../HelloWorldApp.app/app/app.js`.
@@ -43,15 +45,17 @@ Resolves to `/private/.../HelloWorldApp.app/app/app.js`.
 ### Loading Files from the App Bundle
 Paths starting with `~` are resolved relative to the app bundle:
 
-```javascript
+```JavaScript
 require('~/user-module/index.js')
+```
+user-module/index.js';
 ```
 Resolves to `/private/.../HelloWorldApp.app/app/user-module/index.js`.
 
 ### Loading NativeScript Modules
 Paths starting with no special symbol are resolved relative to the `tns_modules` folder:
 
-```javascript
+```JavaScript
 require('camera/camera.js');
 ```
 Resolves to `/private/.../HelloWorldApp.app/app/tns_modules/camera/camera.js`.
@@ -61,7 +65,7 @@ For more information about using NativeScript and Node plugins see [Plugins.md](
 ### Loading Modules Relatively
 Paths starting with `.` or `..` are resolved relative to the calling module:
 
-```javascript
+```JavaScript
 // In `app/user-module/index.js`:
 require('./helper.js');
 ```
@@ -82,7 +86,7 @@ In each module, the `module` variable is a reference to the object representing 
 ## Global Require Function
 A `global.require` function is available and useful in the context of the App Inspector because it can be called outside the context of an evaluating module. It resolves relative to the `app` folder:
 
-```javascript
+```JavaScript
 global.require('./user-module');
 ```
 Resolves to `/private/.../HelloWorldApp.app/app/user-module/index.js`.


### PR DESCRIPTION
Removed dead link to a non-existing article about the metadata generator tool (that is now part of the Android runtime).  Related to a feedback form thread.

Added note about using `require` vs `import`