### PR TITLE
refactor: added link to linear gradient examples

### DIFF
--- a/docs/ui/styling.md
+++ b/docs/ui/styling.md
@@ -541,6 +541,7 @@ This list of properties can be set in CSS or through the style property of each 
 | CSS Property          | JavaScript Property   | Description     |
 |:----------------------|:----------------------|:----------------|
 | `color`               | `color`               | Sets a solid-color value to the matched view’s foreground. |
+| `background`          | `background`          | Sets a solid-color value or [a linear gradient](https://docs.nativescript.org/ui/styling) to the matched view’s background. |
 | `background-color`    | `backgroundColor`     | Sets a solid-color value to the matched view’s background. |
 | `placeholder-color`   | `placeholderColor`    | Sets the placeholder (hint) font color to matched views. |
 | `background-image`    | `backgroundImage`     | Sets a image url to the matched view’s background image. |

--- a/docs/ui/styling.md
+++ b/docs/ui/styling.md
@@ -541,7 +541,7 @@ This list of properties can be set in CSS or through the style property of each 
 | CSS Property          | JavaScript Property   | Description     |
 |:----------------------|:----------------------|:----------------|
 | `color`               | `color`               | Sets a solid-color value to the matched view’s foreground. |
-| `background`          | `background`          | Sets a solid-color value or [a linear gradient](https://docs.nativescript.org/ui/styling) to the matched view’s background. |
+| `background`          | `background`          | Sets a solid-color value or [a linear gradient](https://docs.nativescript.org/cookbook/ui/styling) to the matched view’s background. |
 | `background-color`    | `backgroundColor`     | Sets a solid-color value to the matched view’s background. |
 | `placeholder-color`   | `placeholderColor`    | Sets the placeholder (hint) font color to matched views. |
 | `background-image`    | `backgroundImage`     | Sets a image url to the matched view’s background image. |


### PR DESCRIPTION
Related to linear gradient feature and [Cookbook examples](https://github.com/NativeScript/nativescript-sdk-examples-js/pull/21)  Note that the Cookbook examples are on PR and the Gradient section will appear after docs is published.