### PR TITLE
docs(Android virtual devices): add sdkmanager tip for downloading images

### DIFF
--- a/docs/tooling/android-virtual-devices.md
+++ b/docs/tooling/android-virtual-devices.md
@@ -51,7 +51,7 @@ For example, the following command creates an AVD named `test` using the x86 sys
 avdmanager create avd -n test -k "system-images;android-25;google_apis;x86"
 ```
 
-> **Note:** The above command suggest that the system image is already downloaded.
+> **Note:** The above command suggest that the system image is already downloaded. To download an image use the `sdkmanager`. For example  `sdkmanager "system-images;android-25;google_apis;x86"`
 
 The following describes the usages for the other options:
 -c {path|size}: The path to the SD card image for this AVD or the size of a new SD card image to create for this AVD, in KB or MB, denoted with K or M. For example, -c path/to/sdcard/ or -c 1000M.


### PR DESCRIPTION
Added the `sdkmanager` tip to save a few minutes of googling.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] If there is an issue related with this PR, point it out here.

## What is the current state of the documentation article?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Under the `avdmanager create...` command is a note saying that the command suggests that the appropriate image is already downloaded.

## What is the new state of the documentation article?
<!-- Describe the changes. -->
The note now includes a command to download the required image if it's not already on the system, saving someone a few minutes of googling
