### PR TITLE
docs: Remove vectors and struct with const array members limitations …

### DIFF
--- a/docs/runtimes/ios/Limitations.md
+++ b/docs/runtimes/ios/Limitations.md
@@ -11,8 +11,8 @@ The following members can not be accessed from JavaScript:
 
 * Unions
 * Variadic Objective-C methods, function pointers, blocks
-* Structs with constant size array members
-* Vectors
-* Inline functions
+* Inline functions<sup>1</sup>
 * `int64_t`, `uint64_t` outside the [-2^53, 2^53] range
 * `long double`, `int128_t`, `uint128_t`
+
+<sup>1</sup>some of the most used inline functions are [implemented in JavaScript](https://github.com/NativeScript/ios-runtime/blob/release/src/NativeScript/inlineFunctions.js) and therefore available


### PR DESCRIPTION
…/ add reference for inline functions

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] If there is an issue related with this PR, point it out here.

## What is the current state of the documentation article?
According to current docs iOS runtime does not support vector types and const array size struct members.

## What is the new state of the documentation article?
Support for the abovementioned types is implemented in NS 4.1.0.


