### PR TITLE
docs: add python `six` installation to requirements

### DIFF
--- a/docs/start/ns-setup-os-x.md
+++ b/docs/start/ns-setup-os-x.md
@@ -24,6 +24,7 @@ This page contains a list of all system requirements needed to build and run Nat
     * Command-line tools for Xcode
     * xcodeproj ruby gem
     * CocoaPods
+    * The `six` python package
     * (Optional) xcproj command line tool
 * For Android development
     * JDK 8
@@ -65,6 +66,11 @@ Complete the following steps to setup NativeScript on your macOS development mac
     1. Install [CocoaPods](https://guides.cocoapods.org/using/getting-started.html)
 
         <pre class="add-copy-button"><code class="language-terminal">sudo gem install cocoapods
+        </code></pre>
+
+    1. Install python `six` package
+
+        <pre class="add-copy-button"><code class="language-terminal">pip install six
         </code></pre>
 
     1. (Optional) If you are using Xcode 7.3 as well as an older version of CocoaPods (0.39.0 or earlier), you must install the `xcproj` command-line tool by running `brew install xcproj` in your terminal. You can check your CocoaPods version with pod --version.


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] If there is an issue related with this PR, point it out here:
https://github.com/NativeScript/nativescript-cli/issues/3678

## What is the current state of the documentation article?
Python `six` package is not mentioned as a dependency. As such, at least the CI environments will fail to run NativeScripts commands. 

## What is the new state of the documentation article?
Listed `six` as a dependency and added step on how to install it

Fixes/Implements/Closes #[Issue Number].
https://github.com/NativeScript/nativescript-cli/issues/3678

