### PR TITLE
Fix link to Chapter 2 of tutorial

### DIFF
--- a/docs/start/tutorial/chapter-1.md
+++ b/docs/start/tutorial/chapter-1.md
@@ -371,5 +371,5 @@ At this point your UI looks good, but the app still doesn't actually do anything
 > **TIP**: The community-written [NativeScript Image Builder](http://nsimage.brosteins.com/) can help you generate images in the appropriate resolutions for iOS and Android.
 
 <div class="next-chapter-link-container">
-  <a href="/tutorial/chapter-2">Continue to Chapter 2—Application Logic</a>
+  <a href="/start/tutorial/chapter-2">Continue to Chapter 2—Application Logic</a>
 </div>


### PR DESCRIPTION
Bottom of Chapter 1 has incorrect link for Chapter 2, missing a /start/ element in path.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] If there is an issue related with this PR, point it out here.

## What is the current state of the documentation article?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new state of the documentation article?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

