### PR TITLE
Typo

### DIFF
--- a/docs/ui/dialogs.md
+++ b/docs/ui/dialogs.md
@@ -283,7 +283,7 @@ dialogs.action({
     actions: ["Option1", "Option2"]
 }).then(result => {
     console.log("Dialog result: " + result);
-    if(result == "Options1"){
+    if(result == "Option1"){
         //Do action1
     }else if(result == "Option2"){
         //Do action2


### PR DESCRIPTION
Example won't work if 'Options1' is used instead of 'Option1'.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] If there is an issue related with this PR, point it out here.

## What is the current state of the documentation article?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new state of the documentation article?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

