### PR TITLE
refactor: README links + redirect for base Angular link

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ This documentation is built using [Jekyll](https://jekyllrb.com/docs/home/). Mor
 
 There are two versions of the NativeScript documentation that generate similar output: `nativescript` and `angular`. The former builds the vanilla NativeScript docs at [docs.nativescript.org](https://docs.nativescript.org/), while the latter discusses Angular-specific topics at [docs.nativescript.org/angular/start/introduction](https://docs.nativescript.org/angular/start/introduction).
 
-
 Most of the content in this repository is shared between the two environments, but occasionally you may need to add environment-specific content. When you have this need you have a few options.
 
 1. If you would like a page to appear in a single environment, add an `environment: angular` or `environment: nativescript` property to that page's front matter. Pages marked with an `environment` property will appear in a single environment, and pages _not_ marked with an `environment` property will be shared across all environments.

--- a/build/nginx.conf
+++ b/build/nginx.conf
@@ -99,11 +99,14 @@ http {
 		rewrite ^/publishing/publishing-android-apps $proto://$host_and_port/tooling/publishing/publishing-android-apps permanent;
 		rewrite ^/publishing/publishing-ios-apps $proto://$host_and_port/tooling/publishing/publishing-ios-apps permanent;
 
+		# Redirect base Angular link
+		rewrite ^/angular$ $proto://$host_and_port/angular/start/introduction permanent;
+
 		# Redirect Angular Code Samples to UI Widgets
 		rewrite ^/angular/code-samples/ui/(.*) $proto://$host_and_port/angular/ui/ng-ui-widgets/$1 permanent;
 		rewrite ^/angular/code-samples/ui/layouts $proto://$host_and_port/angular/ui/layouts/layout-containers permanent;
 
-		# Redirect Angular code-samples (that were outside UI section)
+		# Redirect Angular Code Samples (that were outside UI section)
 		rewrite ^/angular/cookbook/application $proto://$host_and_port/angular/ng-framework-modules/application permanent;
 		rewrite ^/angular/cookbook/application-settings $proto://$host_and_port/angular/ng-framework-modules/application-settings permanent;
 		rewrite ^/angular/cookbook/color $proto://$host_and_port/angular/ng-framework-modules/color permanent;
@@ -151,7 +154,7 @@ http {
 		rewrite ^/angular/tutorial/ng-chapter-6 $proto://$host_and_port/angular/start/tutorial/ng-chapter-5 permanent;
 		rewrite ^/angular/tutorial/ng-chapter-7 $proto://$host_and_port/angular/start/ng-next-steps permanent;
 
-		# Redirect the JavaScript Groceris tutorial links
+		# Redirect the JavaScript Groceries tutorial links
 		rewrite ^/tutorial/chapter-0 $proto://$host_and_port/start/hello-world/chapter-0 permanent;
 
 		# Redirect .html extension


### PR DESCRIPTION
The previous redirect of the Angular base link has broken the Angular section due to a regex mistake.
This PR is fixing the issue and redirecting all Angular base links with
```
rewrite ^/angular$ $proto://$host_and_port/angular/start/introduction permanent;
```