### PR TITLE
Move the ndk section under defaultConfig

### DIFF
--- a/docs/tooling/publishing/android-abi-split.md
+++ b/docs/tooling/publishing/android-abi-split.md
@@ -14,8 +14,11 @@ To achieve this you need to enable ABI splits at **app/App_Resources/Android/app
 ```
 android {
 ....
-  ndk {
-    abiFilters.clear()
+  defaultConfig {
+    ....
+    ndk {
+      abiFilters.clear()
+    }
   }
   splits {
     abi {


### PR DESCRIPTION
The `ndk` section should be nested inside `defaultConfig` and not inside `android`. Related to https://github.com/NativeScript/android-runtime/issues/1085