### PR TITLE
fix: broken links in Groceries Core tutorial

### DIFF
--- a/docs/start/tutorial/chapter-1.md
+++ b/docs/start/tutorial/chapter-1.md
@@ -371,5 +371,5 @@ At this point your UI looks good, but the app still doesn't actually do anything
 > **TIP**: The community-written [NativeScript Image Builder](http://nsimage.brosteins.com/) can help you generate images in the appropriate resolutions for iOS and Android.
 
 <div class="next-chapter-link-container">
-  <a href="/tutorial/chapter-2">Continue to Chapter 2—Application Logic</a>
+  <a href="/start/tutorial/chapter-2">Continue to Chapter 2—Application Logic</a>
 </div>

--- a/docs/start/tutorial/chapter-2.md
+++ b/docs/start/tutorial/chapter-2.md
@@ -231,5 +231,5 @@ What's really cool is that the binding is two-way. Meaning, when the user types 
 To use these values, and to make this login functional by typing your app into a backend service, you're going to need the ability to make HTTP calls. And to make HTTP calls in NativeScript you use the NativeScript fetch module. Let's look at how NativeScript modules work.
 
 <div class="next-chapter-link-container">
-  <a href="/tutorial/chapter-3">Continue to Chapter 3—NativeScript Modules</a>
+  <a href="/start/tutorial/chapter-3">Continue to Chapter 3—NativeScript Modules</a>
 </div>

--- a/docs/start/tutorial/chapter-3.md
+++ b/docs/start/tutorial/chapter-3.md
@@ -578,5 +578,5 @@ Now that you have the login, registration, and list pages complete, let’s enha
 > **TIP**: There are several modules that come out of the box with your NativeScript installation that we did not have time to cover in this guide—including a [file-system helper]({%ns_cookbook file-system%}), a [timer module]({%ns_cookbook timer%}), and a whole lot more. Make sure to peruse the “API Reference” of the NativeScript documentation, or just look around your `node_modules/tns-core-modules` folder to see all of what’s available.
 
 <div class="next-chapter-link-container">
-  <a href="/tutorial/chapter-4">Continue to Chapter 4—Plugins and npm Modules</a>
+  <a href="/start/tutorial/chapter-4">Continue to Chapter 4—Plugins and npm Modules</a>
 </div>

--- a/docs/start/tutorial/chapter-4.md
+++ b/docs/start/tutorial/chapter-4.md
@@ -204,5 +204,5 @@ If you're looking for NativeScript plugins start by searching [NativeScript Mark
 Between NativeScript modules, npm modules, and NativeScript plugins, the NativeScript framework provides a lot of functionality you can use to build your next app. However, we've yet to talk about NativeScript's most powerful feature: the ability to directly access iOS and Android APIs in JavaScript. Let's look at how it works.
 
 <div class="next-chapter-link-container">
-  <a href="/tutorial/chapter-5">Continue to Chapter 5—Accessing Native APIs</a>
+  <a href="/start/tutorial/chapter-5">Continue to Chapter 5—Accessing Native APIs</a>
 </div>


### PR DESCRIPTION
Reported via the feedback form