### PR TITLE
docs: fix typo in iOS publishing documentation

### DIFF
--- a/docs/tooling/publishing/publishing-ios-apps.md
+++ b/docs/tooling/publishing/publishing-ios-apps.md
@@ -34,7 +34,7 @@ The *Bundle ID* is used to precisely identify your app at various situations and
 For more information consider [the 'About Bundle IDs' section in the following article](https://developer.apple.com/library/ios/documentation/IDEs/Conceptual/AppDistributionGuide/ConfiguringYourApp/ConfiguringYourApp.html).
 
 ### App name
-This is the display name for your app. It is purely cosmetic but highly important. Fot example, it will appear under the app icon.
+This is the display name for your app. It is purely cosmetic but highly important. For example, it will appear under the app icon.
 The value is stored in the `app/App_Resources/iOS/Info.plist` file as the `CFBundleDisplayName` key.
 
 ### App icons


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] If there is an issue related with this PR, point it out here.

## What is the current state of the documentation article?
Small typo "Fot example"

## What is the new state of the documentation article?
Fixes this typo to "For example"

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

