### PR TITLE
docs: remove obsolete option from NativeScriptSnapshotPlugin options

### DIFF
--- a/docs/tooling/publishing/android-abi-split.md
+++ b/docs/tooling/publishing/android-abi-split.md
@@ -49,7 +49,6 @@ if (env.snapshot) {
         projectRoot: __dirname,
         webpackConfig: config,
         targetArchs: ["arm", "arm64", "ia32"],
-        tnsJavaClassesOptions: { packages: ["tns-core-modules" ] },
         useLibs: true,
         androidNdkPath: "/Library/android-sdk-macosx/ndk-bundle"
     }));


### PR DESCRIPTION
The `tnsJavaClassesOptions` is no longer in configuration
schema of the plugin.