### PR TITLE
Update ns-setup-linux.md

### DIFF
--- a/docs/start/ns-setup-linux.md
+++ b/docs/start/ns-setup-linux.md
@@ -72,10 +72,13 @@ Complete the following steps to set up NativeScript on your Linux development ma
     1. After the download completes, unpack the downloaded archive into a folder, such as `/android/sdk`
        * The archive you just extracted was the `tools` folder, so in this case it would be at: `/android/sdk/tools`
     1. Set the ANDROID_HOME system environment variable.
-        <pre><code class="language-terminal">export ANDROID_HOME=Path to Android installation directory
+        <pre><code class="language-terminal">sudo -H gedit /etc/environment
         </code></pre>
-        For example: `ANDROID_HOME=/android/sdk`
+    1. In a text file which was opened, paste in the path to your variable (at the new line).
+    
+    For example: `ANDROID_HOME=/android/sdk`
         <blockquote><b>NOTE</b>: This is the directory that contains the <code>tools</code> (just installed) and <code>platform-tools</code> (installed by scripts in the next step) directories.</blockquote>
+     1. Logout from current user and login again so environment variables changes take place.
 
 1. Install all packages for the Android SDK Platform 25, Android SDK Build-Tools 27.0.3 or later, Android Support Repository, Google Repository and any other SDKs that you may need. You can alternatively use the following command, which will install all required packages.
 


### PR DESCRIPTION
The previous solution only creates variable for one session. After the restart of the system variable was gone and the whole process was broken. Even after the end of this set up tutorial, during `tns doctor` command, there was a lot of errors about Android SDK. Creating a permanent environment variable fix this and after restart of the system this set up instruction works.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] If there is an issue related with this PR, point it out here.

## What is the current state of the documentation article?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new state of the documentation article?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

