### PR TITLE
removed internal TOCs from UI sections

### DIFF
--- a/docs/ui/gestures.md
+++ b/docs/ui/gestures.md
@@ -23,18 +23,6 @@ As the first parameter, you pass an `on` or `off` method and the type of gesture
    - **type** - _Number_ | **name** - _String_ | **names** - Comma separated _String_
    - **callback** - _Function_(args _GestureEventData_)
 
-The next sections introduce you to all the gestures recognized by NativeScript:
-
-* [Tap](#tap)
-* [Double Tap](#double-tap)
-* [Long Press](#long-press)
-* [Swipe](#swipe)
-* [Pan](#pan)
-* [Pinch](#pinch)
-* [Rotation](#rotation)
-* [Touch](#touch)
-{% nativescript %}* [Subscribing to Multiple Gestures and Events](#subscribing-to-multiple-gestures-and-events)
-{% endnativescript %}
 ## Tap
 
 **Action: Briefly touch the screen.**

--- a/docs/ui/layouts/layout-containers.md
+++ b/docs/ui/layouts/layout-containers.md
@@ -7,12 +7,6 @@ previous_url: /layout-containers
 ---
 
 # Layout Containers
-* [AbsoluteLayout](#absolutelayout)
-* [DockLayout](#docklayout)
-* [GridLayout](#gridlayout)
-* [StackLayout](#stacklayout)
-* [WrapLayout](#wraplayout)
-* [FlexboxLayout](#flexboxlayout)
 
 ## [AbsoluteLayout]({%ns_cookbook ui/layouts/absolute-layout%})
 The AbsoluteLayout is the simplest layout in NativeScript. It uses absolute left-top coordinates to position its children. The AbsoluteLayout will not enforce any layout constraints on its children and will not resize them at runtime when its size changes.
@@ -26,7 +20,6 @@ None.
 | left     | Gets or sets the distance, in pixels, between the left edge of the child and the left edge of its parent AbsoluteLayout client area. |
 | top     | Gets or sets the distance, in pixels, between the top edge of the child and the top edge of its parent AbsoluteLayout client area. |
 
-### Sample
 {% nativescript %}
 ```XML
 <Page xmlns="http://schemas.nativescript.org/tns.xsd">
@@ -45,7 +38,6 @@ None.
 
 ![AbsoluteLayout](../img/modules/layouts/absolute-layout.png "AbsoluteLayout")
 
-### Sample (margin)
 {% nativescript %}
 ```XML
 <Page xmlns="http://schemas.nativescript.org/tns.xsd">
@@ -75,7 +67,7 @@ The DockLayout is a layout that provides a docking mechanism for child elements 
 | -------- | ------------|
 | dock     | Specifies the Dock position of a child element that is inside a DockLayout. Possible values are `left`, `top`, `right` and `bottom`. |
 
-### Sample (stretchLastChild="false")
+_Example for `stretchLastChild="false"`_
 {% nativescript %}
 ```XML
 <Page xmlns="http://schemas.nativescript.org/tns.xsd">
@@ -94,7 +86,7 @@ The DockLayout is a layout that provides a docking mechanism for child elements 
 
 ![DockLayout](../img/modules/layouts/dock-layout1.png "DockLayout1")
 
-### Sample (stretchLastChild="true")
+_Example for `stretchLastChild="true"`_
 {% nativescript %}
 ```XML
 <Page xmlns="http://schemas.nativescript.org/tns.xsd">
@@ -113,7 +105,7 @@ The DockLayout is a layout that provides a docking mechanism for child elements 
 
 ![DockLayout](../img/modules/layouts/dock-layout2.png "DockLayout1")
 
-### Sample (multiple child elements on one side)
+_Example for multiple child elements on one side_
 {% nativescript %}
 ```XML
 <Page xmlns="http://schemas.nativescript.org/tns.xsd">
@@ -152,7 +144,7 @@ The GridLayout is a layout that arranges its child elements in a table structure
 | rowSpan  | Gets or sets a value that indicates the total number of rows that child content spans within a GridLayout. |
 | colSpan  | Gets or sets a value that indicates the total number of columns that child content spans within a GridLayout. |
 
-### Sample
+_Example for basic Grid usage_
 {% nativescript %}
 ```XML
 <Page xmlns="http://schemas.nativescript.org/tns.xsd">
@@ -174,7 +166,7 @@ The GridLayout is a layout that arranges its child elements in a table structure
 
 ![GridLayout](../img/modules/layouts/grid-layout.png "GridLayout")
 
-### Sample (star-sizing)
+_Example for sizing with star (`*`)_
 - Columns: One star plus two stars is equal to three stars. (\* + 2\* = 3\*). Divide GridLayout width (300) by 3 to get 100. So first column is 1 x 100 = 100 pixels wide and second column is 2 x 100 = 200 pixels wide. 100 + 200 = 300.
 - Rows: Two stars plus three stars is equal to five stars. (2\* + 3\* = 5\*). Divide GridLayout height (300) by 5 to get 60. So first row is 2 x 60 = 120 pixels high and second row is 3 x 60 = 180 pixels high. 120 + 180 = 300.
 {% nativescript %}
@@ -195,7 +187,7 @@ The GridLayout is a layout that arranges its child elements in a table structure
 
 ![GridLayout](../img/modules/layouts/grid-layout1.png "GridLayout")
 
-### Sample (fixed and auto)
+_Example for fixed and auto sizing_
 - The first column and the first row are `auto`. This means that they are measured with infinite available space and then sized to their content.
 - The first column and the first row have fixed sizes of 100 and 100 respectively. They will be exactly this wide/high regardless of their children's dimensions. They would still be exactly this wide/high even if they don't have any children.
 {% nativescript %}
@@ -216,7 +208,7 @@ The GridLayout is a layout that arranges its child elements in a table structure
 
 ![GridLayout](../img/modules/layouts/grid-layout2.png "GridLayout")
 
-### Sample (no width and horizontalAlignment != stretch)
+_Example for no width and horizontalAlignment != stretch_
 When the GridLayout has no explicit `width` set and its `horizontalAlignment` is not `stretch`, the star columns will not occupy the entire available space (200 from parent StackLayout).
 
 {% nativescript %}
@@ -237,7 +229,7 @@ When the GridLayout has no explicit `width` set and its `horizontalAlignment` is
 
 ![GridLayout](../img/modules/layouts/grid-layout3.png "GridLayout")
 
-### Sample (column stretching)
+_Example for column stretching_
 Label 3 has a fixed width of 150 pixels. Label 1 is given more space than it actually needs, because Label 3 stretches the auto column.
 {% nativescript %}
 ```XML
@@ -256,7 +248,7 @@ Label 3 has a fixed width of 150 pixels. Label 1 is given more space than it act
 
 ![GridLayout](../img/modules/layouts/grid-layout4.png "GridLayout")
 
-### Sample (complex)
+_Example for complex structure
 `Image` has fixed width and height of 72 and span the both rows. For the first `Label` is given more space by using `colSpan="2"`. Third `Lable` is given more space than it actually needs, because fourth `Label` stretches the auto column.
 
 {% nativescript %}
@@ -278,7 +270,7 @@ Label 3 has a fixed width of 150 pixels. Label 1 is given more space than it act
 ![GridLayout](../img/modules/layouts/grid-layout5.png "GridLayout")
 
 
-### Sample (Create grid dynamically via code behind)
+_Example for creating grid dynamically via code behind_
 
 > You can find a runnable version of this example in NativeScript Playground for JavaScript [here](https://play.nativescript.org/?template=play-js&id=uxpI70) and for TypeScript [here](https://play.nativescript.org/?template=play-tsc&id=FHnThH).
 
@@ -419,7 +411,7 @@ The StackLayout stacks its child elements below or beside each other, depending 
 ### Child Properties
 None.
 
-### Sample (orientation="vertical")
+_Example for `orientation="vertical"`_
 {% nativescript %}
 ```XML
 <Page xmlns="http://schemas.nativescript.org/tns.xsd">
@@ -438,7 +430,7 @@ None.
 
 ![StackLayout](../img/modules/layouts/stack-layout1.png "StackLayout")
 
-### Sample (orientation="horizontal")
+_Example for `orientation="horizontal"`_
 {% nativescript %}
 ```XML
 <Page xmlns="http://schemas.nativescript.org/tns.xsd">
@@ -457,7 +449,7 @@ None.
 
 ![StackLayout](../img/modules/layouts/stack-layout2.png "StackLayout")
 
-### Sample (horizontal alignment of children)
+_Example for horizontal alignment of children_
 {% nativescript %}
 ```XML
 <Page xmlns="http://schemas.nativescript.org/tns.xsd">
@@ -476,7 +468,7 @@ None.
 
 ![StackLayout](../img/modules/layouts/stack-layout3.png "StackLayout")
 
-### Sample (vertical alignment of children)
+_Example for vertical alignment of children_
 {% nativescript %}
 ```XML
 <Page xmlns="http://schemas.nativescript.org/tns.xsd">
@@ -507,7 +499,7 @@ The WrapLayout is similar to the StackLayout, but it does not just stack all chi
 ### Child Properties
 None.
 
-### Sample (orientation="horizontal")
+_Example for `orientation="horizontal"`_
 {% nativescript %}
 ```XML
 <Page xmlns="http://schemas.nativescript.org/tns.xsd">
@@ -526,7 +518,7 @@ None.
 
 ![WrapLayout](../img/modules/layouts/wrap-layout1.png "WrapLayout")
 
-### Sample (orientation="vertical")
+_Example for `orientation="vertical"`_
 {% nativescript %}
 ```XML
 <Page xmlns="http://schemas.nativescript.org/tns.xsd">
@@ -589,7 +581,7 @@ The FlexboxLayout is a non-conforming implementation of the [CSS Flexible Box La
 
 > **NOTE:** There is a limitation for `alignSelf` in **iOS** the `baseline` option can **not** be used.
 
-### Sample (flexDirection="row", alignItems="stretch" (default))
+_Example for `flexDirection="row"`, `alignItems="stretch"` (default)_
 {% nativescript %}
 ```XML
 <Page xmlns="http://schemas.nativescript.org/tns.xsd">
@@ -608,7 +600,7 @@ The FlexboxLayout is a non-conforming implementation of the [CSS Flexible Box La
 
 ![FlexboxLayout](../img/modules/layouts/flexbox-layout1.png "FlexboxLayout")
 
-### Sample (flexDirection="column", alignItems="stretch" (default))
+_Example for `flexDirection="column"`, `alignItems="stretch"` (default)_
 {% nativescript %}
 ```XML
 <Page xmlns="http://schemas.nativescript.org/tns.xsd">
@@ -646,7 +638,7 @@ The FlexboxLayout is a non-conforming implementation of the [CSS Flexible Box La
 
 ![FlexboxLayout](../img/modules/layouts/flexbox-layout3.png "FlexboxLayout")
 
-### Sample (flexDirection="row", custom order)
+_Example for `flexDirection="row"`, custom order_
 {% nativescript %}
 ```XML
 <Page xmlns="http://schemas.nativescript.org/tns.xsd">
@@ -665,7 +657,7 @@ The FlexboxLayout is a non-conforming implementation of the [CSS Flexible Box La
 
 ![FlexboxLayout](../img/modules/layouts/flexbox-layout4.png "FlexboxLayout")
 
-### Sample (flexWrap="wrap")
+_Example for `flexWrap="wrap"`_
 {% nativescript %}
 ```XML
 <Page xmlns="http://schemas.nativescript.org/tns.xsd">
@@ -684,7 +676,7 @@ The FlexboxLayout is a non-conforming implementation of the [CSS Flexible Box La
 
 ![FlexboxLayout](../img/modules/layouts/flexbox-layout6.png "FlexboxLayout")
 
-### Sample (flexDirection="column-reverse", justifyContent="space-around", alignSelf)
+_Example for `flexDirection="column-reverse"`, `justifyContent="space-around"`, `alignSelf`_
 {% nativescript %}
 ```XML
 <Page xmlns="http://schemas.nativescript.org/tns.xsd">

--- a/docs/ui/layouts/layouts.md
+++ b/docs/ui/layouts/layouts.md
@@ -8,27 +8,16 @@ previous_url: /layouts
 
 # User Interface Layouts
 
-NativeScript provides a recursive layout system that sizes and positions [views][views] on the screen.
-
-* [Layout Process](#layout-process)
-	* [Measure Pass](#measure-pass)
-	* [Layout Pass](#layout-pass)
-	* [Alignment](#alignment)
-	* [Margins](#margins)
-* [Layouts](#layouts)
-	* [Layout Paddings](#layout-paddings)
-	* [Predefined Layouts](#predefined-layouts)
-* [Percent Support](#percentage-support)
-
 ## Layout Process
 
-Layout is the process of measuring and positioning the child views of a [Layout][Layout] container. Layout is an intensive process whose speed and performance depend on the count of the children and the complexity of the layout container. For example, a simple layout container such as [AbsoluteLayout][AbsoluteLayout] might perform better than a more complex layout container, such as [GridLayout][GridLayout].
+NativeScript provides a recursive layout system that sizes and positions views on the screen.
+Layout is the process of measuring and positioning the child views of a Layout container. Layout is an intensive process whose speed and performance depend on the count of the children and the complexity of the layout container. For example, a simple layout container such as `AbsoluteLayout` might perform better than a more complex layout container, such as `GridLayout`.
 
-Layout completes in two passes&mdash;a measure pass and a layout pass. Every layout container provides its own `onMeasure()` and `onLayout()` methods to achieve its own specific layout.
+Layout completes in two passes&mdash;a measure pass and a layout pass. Every layout container provides its own `onMeasure` and `onLayout` methods to achieve its own specific layout.
 
 ### Measure Pass
 
-During the measure pass, each [view][view] is measured to retrieve its desired size. The measure pass evaluates the following properties:
+During the measure pass, each `View` is measured to retrieve its desired size. The measure pass evaluates the following properties:
 
 * width
 * height
@@ -42,7 +31,7 @@ During the measure pass, each [view][view] is measured to retrieve its desired s
 
 ### Layout Pass
 
-During the layout pass, each [view][view] is placed in a specific layout slot. This slot is determined by the desired size of the view (retrieved from the measure pass) and the following properties:
+During the layout pass, each `View` is placed in a specific layout slot. This slot is determined by the desired size of the view (retrieved from the measure pass) and the following properties:
 
 - marginTop
 - marginRight
@@ -73,7 +62,7 @@ The following table shows the valid values of `verticalAlignment`.
 | bottom  | The view is aligned to the bottom of the layout slot of the parent element. |
 | stretch | The view is stretched to fill the layout slot of the parent element; `height` takes precedence, if set. |
 
-### Margins
+## Margins
 
 The four margin properties (`marginTop`, `marginRight`, `marginBottom` and `marginLeft`) describe the distance between a view and its parent.
 
@@ -87,7 +76,7 @@ When you set margins through XML, you can choose between the following approache
 
 `Layout` is the base class for all views that provide positioning of child elements.
 
-You can use the various layout containers to position elements. They evaluate the base properties of [view][view] such as `width`, `height`, `minWidth` and alignments, and expose additional properties for positioning child views (such as the four paddings).
+You can use the various layout containers to position elements. They evaluate the base properties of `View` such as `width`, `height`, `minWidth` and alignments, and expose additional properties for positioning child views (such as the four paddings).
 
 ### Layout Paddings
 
@@ -112,15 +101,6 @@ The following table shows predefined layouts that NativeScript provides.
 | [StackLayout][StackLayout] | This layout arranges its children horizontally or vertically. The direction is set with the orientation property. | ![StackLayout android](../img/gallery/android/stackLayoutPage.png "StackLayout android")|
 | [WrapLayout][WrapLayout] | This layout positions its children in rows or columns, based on the orientation property, until the space is filled and then wraps them on a new row or column. | ![WrapLayout android](../img/gallery/android/wrapLayoutPage.png "WrapLayout android")|
 
-[views]: {%slug components %}
-[View]: /api-reference/classes/_ui_core_view_.view.html
-[Layout]: /api-reference/classes/_ui_layouts_layout_.layout.html
-[FlexboxLayout]: {%ns_cookbook ui/layouts/flexbox-layout%}
-[AbsoluteLayout]: {%ns_cookbook ui/layouts/absolute-layout%}
-[DockLayout]: {%ns_cookbook ui/layouts/dock-layout%}
-[GridLayout]: {%ns_cookbook ui/layouts/grid-layout%}
-[StackLayout]: {%ns_cookbook ui/layouts/stack-layout%}
-[WrapLayout]: {%ns_cookbook ui/layouts/wrap-layout%}
 
 ### Percentage Support
 

--- a/docs/ui/styling.md
+++ b/docs/ui/styling.md
@@ -8,19 +8,6 @@ previous_url: /styling
 
 # Styling
 
-This article includes the following topics:
-
-* [Introduction](#introduction)
-* [Applying CSS Styles](#applying-css-styles)
-* [Supported Selectors](#supported-selectors)
-* [Supported CSS Properties](#supported-css-properties)
-* [Accessing NativeScript component properties with CSS](#accessing-nativescript-component-properties-with-css)
-* [Using Fonts](#using-fonts)
-* [Import External CSS](#import-external-css)
-* [Using SASS](#using-sass)
-
-## Introduction
-
 You change the looks and appearance of views (elements) in a NativeScript application similarly to how you do it in a web application&mdash;using Cascading Style Sheets (CSS) or changing the style object of the elements in JavaScript. Only a subset of the CSS language is supported.
 
 Similarly to the [DOM Style Object](http://www.w3schools.com/jsref/dom_obj_style.asp), each View instance exposes a **style** property, which holds all the style properties for the view. When the view is displayed, all its style properties are applied to the underlying native widget.
@@ -33,6 +20,7 @@ Similarly to the [DOM Style Object](http://www.w3schools.com/jsref/dom_obj_style
 {% endangular %}
 
 ## Applying CSS styles
+
 The CSS styles can be set on 3 different levels:
 
 * [Application-wide CSS](#application-wide-css): Applies to every application page
@@ -56,13 +44,13 @@ You can change the name of the file from which the application-wide CSS is loade
 
 {% nativescript %}
 ``` JavaScript
-var application = require("application");
+var application = require("tns-core-modules/application");
 application.setCssFileName("style.css");
 
 application.start({ moduleName: "main-page" });
 ```
 ``` TypeScript
-import { setCssFileName, start as applicationStart } from "application";
+import { setCssFileName, start as applicationStart } from "tns-core-modules/application";
 setCssFileName("style.css");
 
 applicationStart({ moduleName: "main-page" });
@@ -77,24 +65,22 @@ console.log(`fileName ${fileName}`);
 
 ```
 ``` TypeScript
-import { getCssFileName, start } from "application";
+import { getCssFileName, start as applicationStart } from "tns-core-modules/application";
 let fileName = getCssFileName();
 console.log(`fileName ${fileName}`);
 
-start({ moduleName: "main-page" });
+applicationStart({ moduleName: "main-page" });
 ```
-
 {% endnativescript %}
+
 {% angular %}
-
 ```TypeScript
-platformNativeScriptDynamic({bootInExistingPage:false, cssFile:"style.css"});
+platformNativeScriptDynamic({ bootInExistingPage:false, cssFile:"style.css" });
 ```
-
 {% endangular %}
 > The path to the CSS file is relative to the application root folder.
-
 {% nativescript %}
+
 ### Page-specific CSS
 
 When the page's XML declaration file is loaded, NativeScript looks for a CSS file with the same name (if such exists), reads any CSS styles that it finds, and automatically loads and applies them to the page. For example, a page named `mypage.xml` will automatically load any CSS in `mypage.css`. The CSS file must exist in the same folder as the XML file to be automatically applied.
@@ -110,10 +96,14 @@ If you import any [custom components](https://docs.nativescript.org/ui/basics#cu
 ```CSS
 /* myCustomComponent.css */
 /* GOOD: This will ONLY apply to the custom component */
-.mywidget .label { color: blue; }
+.mywidget .label { 
+    color: blue; 
+}
 
 /* BAD: This will apply to the custom component AND potentially to the page where the component is used */
-.label { color: blue; }
+.label { 
+    color: blue; 
+}
 ```
 
 For an example of how styles from custom components get applied, [try this project on the NativeScript Playground](https://play.nativescript.org/?template=play-tsc&id=o87l19&v=3).
@@ -134,6 +124,7 @@ After you have set the default CSS for the page, you can add to it using two met
 
 {% endnativescript %}
 {% angular %}
+
 ### Component-specific CSS
 
 In an Angular application everything is a component, therefore, it is a very common task to add some CSS code that should only apply to one component. Adding component-specific CSS in a NativeScript-Angular app involves using a component’s `styles` or `styleUrls` property.
@@ -589,6 +580,31 @@ This list of properties can be set in CSS or through the style property of each 
 | `padding-left`        | `paddingLeft`         | Sets the left padding of a layout container. |
 | `visibility`          | `visibility`          | Sets the view visibility. Possible values: `visible`, `collapse` (or `collapsed`). |
 | `opacity`             | `opacity`             | Sets the view opacity. The value is in the [0, 1] range. |
+
+
+## Supported Measurment Units
+
+As a measurment units, NativeScript supports **DIPs** (Device Independent Pixels) , **pixels** (via postfix `px`) and **percentages** (partial support for `width`,`height` and `margin`).
+
+The NativeScript's recommended measurment unit is DIP. All measurable properties like `width`, `height`, `margin`, `paddings, border-width`, etc.) support device independent pixels. The font size are always measured in DIP. 
+
+```CSS
+.myLabel {
+    font-size: 28;
+    width: 200;
+    height: 30;
+}
+```
+
+> **Note:** The device independent pixels are equal to the current device screen's scale multiplied by the current device screen's width in pixels.
+```TypeScript
+import * as platformModule from "tns-core-modules/platform";
+let scale =  platformModule.screen.mainScreen.scale;
+let widthPixels = platformModule.screen.mainScreen.widthPixels;
+let DIPs = platformModule.screen.mainScreen.widthDIPs; // scale X widthPixels === DIPs
+```
+
+NativeScript supports **percentage** values for `width`, `height` and `margins`. When a layout pass begins, first the percent values are calculated based on parent available size. This means that on vertical StackLayout if you place two Buttons with `height='50%'` they will get all the available height (e.g., they will fill the StackLayout vertically.). The same applies for `margin`` properties. For example, if you set marginLeft='5%'`, the element will have a margin that corresponds to 5% of the parent's available width.
 
 ## Accessing NativeScript component properties with CSS
 

--- a/docs/ui/theme.md
+++ b/docs/ui/theme.md
@@ -10,31 +10,6 @@ NativeScript’s [styling infrastructure](https://docs.nativescript.org/ui/styli
 
 The NativeScript project provides a core theme that you can add to any of your projects. The theme includes two color schemes, light and dark, as well as a series of convenience class names to help you build elegant user interfaces quickly.
 
-* [Installation](#installation)
-* [Color Schemes](#color-schemes)
-* [Class Names](#class-names)
-    - [Headings](#headings)
-    - [Text](#text)
-    - [Font](#font)
-    - [Padding and Margin](#padding-and-margin)
-    - [Dividers](#dividers)
-    - [Utilities](#utilities)
-    - [Contextual Colors](#contextual-colors)
-    - [Page](#page)
-    - [ActionBar](#actionbar)
-    - [Buttons](#buttons)
-    - [Forms](#forms)
-    - [Images](#images)
-    - [ListViews](#listviews)
-    - [Progress and Activity](#progress-and-activity)
-    - [SideDrawers](#sidedrawers)
-    - [Sliders](#sliders)
-    - [Switches](#switches)
-    - [TabViews](#tabviews)
-* [SASS Usage](#sass-usage)
-* [Status Bar Considerations](#status-bar-considerations)
-* [Uninstalling](#uninstalling)
-* [Contributing](#contributing)
 
 ## Installation
 


### PR DESCRIPTION
Removed obsolete internal TOCs from several articles (new right TOCs are automatically generated based on the markdown headings). Some minor improvements on-the-fly in the articles.