### PR TITLE
Adding a bunch of missing redirects from the tutorial changes

### DIFF
--- a/build/_config.yml
+++ b/build/_config.yml
@@ -131,7 +131,7 @@ navigation:
         title: "Guides"
     "guides/integration-with-existing-ios-and-android-apps":
         position: 100
-        title: "Integration with exisitng iOS and Android apps"
+        title: "Integration with existing iOS and Android apps"
     sidekick:
         position: 150
         title: "SideKick"

--- a/build/nginx.conf
+++ b/build/nginx.conf
@@ -154,9 +154,33 @@ http {
 		rewrite ^/angular/tutorial/ng-chapter-5 $proto://$host_and_port/angular/start/introduction permanent;
 		rewrite ^/angular/tutorial/ng-chapter-6 $proto://$host_and_port/angular/start/introduction permanent;
 		rewrite ^/angular/tutorial/ng-chapter-7 $proto://$host_and_port/angular/start/introduction permanent;
+		rewrite ^/angular/tutorial/ng-chapter-7 $proto://$host_and_port/angular/start/introduction permanent;
+		rewrite ^/start/tutorial/ng-chapter-0 $proto://$host_and_port/angular/start/introduction permanent;
+		rewrite ^/start/tutorial/ng-chapter-1 $proto://$host_and_port/angular/start/introduction permanent;
+		rewrite ^/start/tutorial/ng-chapter-2 $proto://$host_and_port/angular/start/introduction permanent;
+		rewrite ^/start/tutorial/ng-chapter-3 $proto://$host_and_port/angular/start/introduction permanent;
+		rewrite ^/start/tutorial/ng-chapter-4 $proto://$host_and_port/angular/start/introduction permanent;
+		rewrite ^/start/tutorial/ng-chapter-5 $proto://$host_and_port/angular/start/introduction permanent;
+		rewrite ^/start/tutorial/ng-chapter-6 $proto://$host_and_port/angular/start/introduction permanent;
+		rewrite ^/start/tutorial/ng-chapter-7 $proto://$host_and_port/angular/start/introduction permanent;
+		rewrite ^/start/tutorial/ng-chapter-7 $proto://$host_and_port/angular/start/introduction permanent;
+
+		rewrite ^/start/hello-world/ng-chapter-0 $proto://$host_and_port/angular/start/introduction permanent;
+		rewrite ^/start/hello-world/ng-chapter-1 $proto://$host_and_port/angular/start/introduction permanent;
+		rewrite ^/angular/start/hello-world/ng-chapter-0 $proto://$host_and_port/angular/start/introduction permanent;
+		rewrite ^/angular/start/hello-world/ng-chapter-1 $proto://$host_and_port/angular/start/introduction permanent;
 
 		# Redirect the JavaScript Groceries tutorial links
-		rewrite ^/tutorial/chapter-0 $proto://$host_and_port/start/introduction permanent;
+		rewrite ^/start/getting-started $proto://$host_and_port/start/introduction permanent;
+		rewrite ^/start/tutorial/chapter-0 $proto://$host_and_port/start/introduction permanent;
+		rewrite ^/start/tutorial/chapter-1 $proto://$host_and_port/start/introduction permanent;
+		rewrite ^/start/tutorial/chapter-2 $proto://$host_and_port/start/introduction permanent;
+		rewrite ^/start/tutorial/chapter-3 $proto://$host_and_port/start/introduction permanent;
+		rewrite ^/start/tutorial/chapter-4 $proto://$host_and_port/start/introduction permanent;
+		rewrite ^/start/tutorial/chapter-5 $proto://$host_and_port/start/introduction permanent;
+		rewrite ^/start/tutorial/chapter-6 $proto://$host_and_port/start/introduction permanent;
+		rewrite ^/start/tutorial/chapter-7 $proto://$host_and_port/start/introduction permanent;
+		rewrite ^/start/tutorial/chapter-7 $proto://$host_and_port/start/introduction permanent;
 
 		# Redirect .html extension
 		rewrite ^/(.*)\.html$ $proto://$host_and_port/$1 redirect;

--- a/build/nginx.conf
+++ b/build/nginx.conf
@@ -146,25 +146,7 @@ http {
 		rewrite ^/best-practices/images-optimisations $proto://$host_and_port/angular/performance-optimizations/images-optimisations permanent;
 
 		# Redirect the Angular Groceries tutorial to proper "Get Started" subsections
-		rewrite ^/angular/tutorial/ng-chapter-0 $proto://$host_and_port/angular/start/introduction permanent;
-		rewrite ^/angular/tutorial/ng-chapter-1 $proto://$host_and_port/angular/start/introduction permanent;
-		rewrite ^/angular/tutorial/ng-chapter-2 $proto://$host_and_port/angular/start/introduction permanent;
-		rewrite ^/angular/tutorial/ng-chapter-3 $proto://$host_and_port/angular/start/introduction permanent;
-		rewrite ^/angular/tutorial/ng-chapter-4 $proto://$host_and_port/angular/start/introduction permanent;
-		rewrite ^/angular/tutorial/ng-chapter-5 $proto://$host_and_port/angular/start/introduction permanent;
-		rewrite ^/angular/tutorial/ng-chapter-6 $proto://$host_and_port/angular/start/introduction permanent;
-		rewrite ^/angular/tutorial/ng-chapter-7 $proto://$host_and_port/angular/start/introduction permanent;
-		rewrite ^/angular/tutorial/ng-chapter-7 $proto://$host_and_port/angular/start/introduction permanent;
-		rewrite ^/start/tutorial/ng-chapter-0 $proto://$host_and_port/angular/start/introduction permanent;
-		rewrite ^/start/tutorial/ng-chapter-1 $proto://$host_and_port/angular/start/introduction permanent;
-		rewrite ^/start/tutorial/ng-chapter-2 $proto://$host_and_port/angular/start/introduction permanent;
-		rewrite ^/start/tutorial/ng-chapter-3 $proto://$host_and_port/angular/start/introduction permanent;
-		rewrite ^/start/tutorial/ng-chapter-4 $proto://$host_and_port/angular/start/introduction permanent;
-		rewrite ^/start/tutorial/ng-chapter-5 $proto://$host_and_port/angular/start/introduction permanent;
-		rewrite ^/start/tutorial/ng-chapter-6 $proto://$host_and_port/angular/start/introduction permanent;
-		rewrite ^/start/tutorial/ng-chapter-7 $proto://$host_and_port/angular/start/introduction permanent;
-		rewrite ^/start/tutorial/ng-chapter-7 $proto://$host_and_port/angular/start/introduction permanent;
-
+		rewrite ^/(angular|start)/tutorial/ng-chapter-\d$ $proto://$host_and_port/angular/start/introduction permanent;
 		rewrite ^/start/hello-world/ng-chapter-0 $proto://$host_and_port/angular/start/introduction permanent;
 		rewrite ^/start/hello-world/ng-chapter-1 $proto://$host_and_port/angular/start/introduction permanent;
 		rewrite ^/angular/start/hello-world/ng-chapter-0 $proto://$host_and_port/angular/start/introduction permanent;
@@ -172,15 +154,8 @@ http {
 
 		# Redirect the JavaScript Groceries tutorial links
 		rewrite ^/start/getting-started $proto://$host_and_port/start/introduction permanent;
-		rewrite ^/start/tutorial/chapter-0 $proto://$host_and_port/start/introduction permanent;
-		rewrite ^/start/tutorial/chapter-1 $proto://$host_and_port/start/introduction permanent;
-		rewrite ^/start/tutorial/chapter-2 $proto://$host_and_port/start/introduction permanent;
-		rewrite ^/start/tutorial/chapter-3 $proto://$host_and_port/start/introduction permanent;
-		rewrite ^/start/tutorial/chapter-4 $proto://$host_and_port/start/introduction permanent;
-		rewrite ^/start/tutorial/chapter-5 $proto://$host_and_port/start/introduction permanent;
-		rewrite ^/start/tutorial/chapter-6 $proto://$host_and_port/start/introduction permanent;
-		rewrite ^/start/tutorial/chapter-7 $proto://$host_and_port/start/introduction permanent;
-		rewrite ^/start/tutorial/chapter-7 $proto://$host_and_port/start/introduction permanent;
+		rewrite ^/start/tutorial/chapter-\d$ $proto://$host_and_port/start/introduction permanent;
+		rewrite ^/tutorial/chapter-\d$ $proto://$host_and_port/start/introduction permanent;
 
 		# Redirect .html extension
 		rewrite ^/(.*)\.html$ $proto://$host_and_port/$1 redirect;


### PR DESCRIPTION
I totally forgot about some of the older URL patterns that still live in Google land :(

This list is long but I think we need them all.