### PR TITLE
docs(code-sharing): add open option to ng serve

### DIFF
--- a/docs/code-sharing/build-process.md
+++ b/docs/code-sharing/build-process.md
@@ -16,7 +16,7 @@ The code-sharing project comes with a build process that is capable of using the
 To build a web app, it is business as usual — just use the Angular CLI to do the job.
 When you call **ng serve** or **ng build**, the Angular CLI will ignore all NativeScript-specific files, as none of the web files directly reference any **.tns** files.
 
- > **ng serve** -> builds a web app from the code-sharing project
+ > **ng serve -o** -> builds a web app from the code-sharing project and opens it in default browser
 
 <!--
 For AOT builds, you may need to give TypeScript a helping hand, by adding NativeScript extensions to **tsconfig.json** exclude list.


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] If there is an issue related with this PR, point it out here.

## What is the current state of the documentation article?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

No `--open` option to `ng serve` command.

## What is the new state of the documentation article?
<!-- Describe the changes. -->

Add `--open` option to `ng serve` command.

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

