### PR TITLE
Add missing emulator package in win/ mac setup

### DIFF
--- a/docs/start/ns-setup-os-x.md
+++ b/docs/start/ns-setup-os-x.md
@@ -127,7 +127,7 @@ Complete the following steps to setup NativeScript on your macOS development mac
 
         1. In addition, install all packages for the Android SDK Platform 25, Android SDK Build-Tools 27.0.3 or later, Android Support Repository, Google Repository and any other SDKs that you may need. You can alternatively use the following command, which will install all required packages.
 
-           <pre class="add-copy-button"><code class="language-terminal">$ANDROID_HOME/tools/bin/sdkmanager "tools" "platform-tools" "platforms;android-25" "build-tools;27.0.3" "extras;android;m2repository" "extras;google;m2repository"
+           <pre class="add-copy-button"><code class="language-terminal">$ANDROID_HOME/tools/bin/sdkmanager "tools" "emulator" "platform-tools" "platforms;android-25" "build-tools;27.0.3" "extras;android;m2repository" "extras;google;m2repository"
            </code></pre>
            
            *If you are behind a corporate proxy, it might be necessary to pass additional arguments. You can check [sdkmanager documentation] (https://developer.android.com/studio/command-line/sdkmanager.html)*

--- a/docs/start/ns-setup-win.md
+++ b/docs/start/ns-setup-win.md
@@ -57,7 +57,7 @@ Complete the following steps to set up NativeScript on your Windows development 
 
 6. Install all packages for the Android SDK Platform 25, Android SDK Build-Tools 27.0.3 or later, Android Support Repository, Google Repository and any other SDKs that you may need. You can alternatively use the following command, which will install all required packages.
 
-    <pre class="add-copy-button"><code class="language-terminal">"%ANDROID_HOME%\tools\bin\sdkmanager" "platform-tools" "platforms;android-25" "build-tools;27.0.3" "extras;android;m2repository" "extras;google;m2repository"
+    <pre class="add-copy-button"><code class="language-terminal">"%ANDROID_HOME%\tools\bin\sdkmanager" "emulator" "platform-tools" "platforms;android-25" "build-tools;27.0.3" "extras;android;m2repository" "extras;google;m2repository"
     </code></pre>
 
 7. Install Android virtual devices (AVDs). There are multiple ways to do it so just choose one:


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] If there is an issue related with this PR, point it out here.

## What is the current state of the documentation article?
When following the windows and macOS advanced setup steps the android emulator does not start after executing 'tns run android'. The command terminates due to a timeout.

## What is the new state of the documentation article?
This pull request fixes the windows and macOS setup. It adds the emulator package to sdkmanager step. This package is required to successfully run a NativeScript app on an android emulator.

