### PR TITLE
fix: broken links

### DIFF
--- a/build/nginx.conf
+++ b/build/nginx.conf
@@ -47,8 +47,9 @@ http {
 		}
 
 		rewrite ^/$ /start/landing.html last;
-
-		{% for directory in site.redirect_directories %}
+		rewrite ^/api-reference$ /api-reference/globals permanent;
+		
+ 		{% for directory in site.redirect_directories %}
 		rewrite ^/{{ directory.path }}/?$ $proto://$host_and_port/{{ directory.url }} permanent;
 		{% endfor %}
 
@@ -63,18 +64,13 @@ http {
 
 		# Redirect old api reference
 		rewrite ^/apireference/(.*)$ $proto://$host_and_port/api-reference permanent;
-
+		
 		# Redirect runtimes under core concepts
-		rewrite ^/runtimes/android/generator(.*)$ $proto://$host_and_port/core-concepts/android-runtime/binding-generator$1 permanent;
-		rewrite ^/angular/runtimes/android/generator(.*)$ $proto://$host_and_port/angular/core-concepts/android-runtime/binding-generator$1 permanent;
-		rewrite ^/runtimes/android/(.*) $proto://$host_and_port/core-concepts/android-runtime/$1 permanent;
-		rewrite ^/angular/runtimes/android/(.*) $proto://$host_and_port/angular/core-concepts/android-runtime/$1 permanent;
-		rewrite ^/runtimes/ios/(.*) $proto://$host_and_port/core-concepts/ios-runtime/$1 permanent;
-		rewrite ^/angular/runtimes/ios/(.*) $proto://$host_and_port/angular/core-concepts/ios-runtime/$1 permanent;
-		rewrite ^/runtimes/ios/how-to/Use-Native-Libraries $proto://$host_and_port/plugins/Use-Native-iOS-Libraries permanent;
-		rewrite ^/angular/runtimes/ios/how-to/Use-Native-Libraries $proto://$host_and_port/angular/plugins/Use-Native-iOS-Libraries permanent;
-		rewrite ^/runtimes/require $proto://$host_and_port/core-concepts/commonjs-modules permanent;
-		rewrite ^/angular/runtimes/require $proto://$host_and_port/angular/core-concepts/commonjs-modules permanent;
+		rewrite ^(/angular)?/runtimes/android/generator(.*)$ $proto://$host_and_port$1/core-concepts/android-runtime/binding-generator$2 permanent;		
+		rewrite ^(/angular)?/runtimes/android/(.*) $proto://$host_and_port$1/core-concepts/android-runtime/$2 permanent;
+		rewrite ^(/angular)?/runtimes/ios/(.*) $proto://$host_and_port$1/core-concepts/ios-runtime/$2 permanent;
+		rewrite ^(/angular)?/runtimes/ios/how-to/Use-Native-Libraries$ $proto://$host_and_port$1/plugins/Use-Native-iOS-Libraries permanent;		
+		rewrite ^(/angular)?/runtimes/require$ $proto://$host_and_port$1/core-concepts/commonjs-modules permanent;
 		
 		# Redirect CLI docs under Tooling
 		rewrite ^/docs-cli/(.*) $proto://$host_and_port/tooling/docs-cli/$1 permanent;
@@ -114,11 +110,10 @@ http {
 
 		rewrite ^/start/troubleshooting$ $proto://$host_and_port/troubleshooting permanent;
 
-
 		# Redirect Angular Code Samples to UI Widgets
 		rewrite ^/angular/code-samples/ui/(.*) $proto://$host_and_port/angular/ui/ng-ui-widgets/$1 permanent;
 		rewrite ^/angular/code-samples/ui/layouts $proto://$host_and_port/angular/ui/layouts/layout-containers permanent;
-		rewrite ^/angular/code-samples/overview $proto://$host_and_port/angular/ui/ng-ui-widgets/action-bar permanent; // page doesn't exist, redirect to first UI widget
+		rewrite ^/angular/code-samples/overview $proto://$host_and_port/angular/ui/ng-ui-widgets/action-bar permanent; # page doesn't exist, redirect to first UI widget
 		rewrite ^/angular/code-samples/modal-page $proto://$host_and_port/angular/ui/ng-ui-widgets/modal-page permanent;
 
 		rewrite ^/angular/code-samples/camera $proto://$host_and_port/angular/ng-hardware-access/camera permanent;
@@ -127,53 +122,18 @@ http {
 		# rewrite ^/angular/ui/(.*) $proto://$host_and_port/angular/ui/components/ permanent;
 
 		# Redirect Angular Code Samples (that were outside UI section)
-		rewrite ^/angular/(cookbook|code-samples)/application $proto://$host_and_port/angular/ng-framework-modules/application permanent;
-		rewrite ^/angular/(cookbook|code-samples)/application-settings $proto://$host_and_port/angular/ng-framework-modules/application-settings permanent;
-		rewrite ^/angular/(cookbook|code-samples)/color $proto://$host_and_port/angular/ng-framework-modules/color permanent;
-		rewrite ^/angular/(cookbook|code-samples)/connectivity $proto://$host_and_port/angular/ng-framework-modules/connectivity permanent;
-		rewrite ^/angular/(cookbook|code-samples)/file-system $proto://$host_and_port/angular/ng-framework-modules/file-system permanent;
-		rewrite ^/angular/(cookbook|code-samples)/fps-meter $proto://$host_and_port/angular/ng-framework-modules/fps-meter permanent;
-		rewrite ^/angular/(cookbook|code-samples)/http $proto://$host_and_port/angular/ng-framework-modules/http permanent;
-		rewrite ^/angular/(cookbook|code-samples)/platform $proto://$host_and_port/angular/ng-framework-modules/platform permanent;
-		rewrite ^/angular/(cookbook|code-samples)/routing $proto://$host_and_port/angular/ng-framework-modules/routing permanent;
-		rewrite ^/angular/(cookbook|code-samples)/timer $proto://$host_and_port/angular/ng-framework-modules/timer permanent;
-		rewrite ^/angular/(cookbook|code-samples)/trace $proto://$host_and_port/angular/ng-framework-modules/trace permanent;
+		rewrite ^/angular/(cookbook|code-samples)/(application|application-settings|color|connectivity|file-system|fps-meter|http|platform|routing|timer|trace) $proto://$host_and_port/angular/ng-framework-modules/$2 permanent;
 
 		# Redirect the Cookbook under Framework Modules
-		rewrite ^/cookbook/trace $proto://$host_and_port/ns-framework-modules/trace permanent;
-		rewrite ^/cookbook/application $proto://$host_and_port/ns-framework-modules/application permanent;
-		rewrite ^/cookbook/application-settings $proto://$host_and_port/ns-framework-modules/application-settings permanent;
-		rewrite ^/cookbook/color $proto://$host_and_port/ns-framework-modules/color permanent;
-		rewrite ^/cookbook/connectivity $proto://$host_and_port/ns-framework-modules/connectivity permanent;
-		rewrite ^/cookbook/console $proto://$host_and_port/ns-framework-modules/console permanent;
+		rewrite ^/cookbook/(trace|application|application-settings|color|connectivity|console|fetch|file-system|formatted-string|formatted-string-ng|fps-meter|http|image-source|platform|timer|xml-parser) $proto://$host_and_port/ns-framework-modules/$1 permanent;
 		rewrite ^/cookbook/data/observable $proto://$host_and_port/ns-framework-modules/observable permanent;
 		rewrite ^/cookbook/data/observable-array $proto://$host_and_port/ns-framework-modules/observable-array permanent;
 		rewrite ^/cookbook/data/virtual-array $proto://$host_and_port/ns-framework-modules/virtual-array permanent;
-		rewrite ^/cookbook/fetch $proto://$host_and_port/ns-framework-modules/fetch permanent;
-		rewrite ^/cookbook/file-system $proto://$host_and_port/ns-framework-modules/file-system permanent;
-		rewrite ^/cookbook/formatted-string $proto://$host_and_port/ui/ns-ui-widgets/formatted-string permanent;
-		rewrite ^/cookbook/formatted-string-ng $proto://$host_and_port/angular/ui/ng-ui-widgets/formatted-string permanent;
-		rewrite ^/cookbook/fps-meter $proto://$host_and_port/ns-framework-modules/fps-meter permanent;
-		rewrite ^/cookbook/http $proto://$host_and_port/ns-framework-modules/http permanent;
-		rewrite ^/cookbook/image-source $proto://$host_and_port/ns-framework-modules/image-source permanent;
-		rewrite ^/cookbook/platform $proto://$host_and_port/ns-framework-modules/platform permanent;
-		rewrite ^/cookbook/timer $proto://$host_and_port/ns-framework-modules/timer permanent;
-		rewrite ^/cookbook/xml-parser $proto://$host_and_port/ns-framework-modules/xml-parser permanent;
-
+		
 		# Redirect the Best Practices articles
-		rewrite ^/best-practices/bundling-with-webpack $proto://$host_and_port/performance-optimizations/bundling-with-webpack permanent;
-		rewrite ^/best-practices/startup-times $proto://$host_and_port/performance-optimizations/startup-times permanent;
-		rewrite ^/best-practices/images-optimisations $proto://$host_and_port/performance-optimizations/images-optimisations permanent;
-		rewrite ^/angular/best-practices/bundling-with-webpack $proto://$host_and_port/angular/performance-optimizations/bundling-with-webpack permanent;
-		rewrite ^/angular/best-practices/startup-times $proto://$host_and_port/angular/performance-optimizations/startup-times permanent;
-		rewrite ^/angular/best-practices/images-optimisations $proto://$host_and_port/angular/performance-optimizations/images-optimisations permanent;
-
-
-		rewrite ^/best-practices/wire-backend $proto://$host_and_port/guides/wire-backend permanent;
-		rewrite ^/best-practices/architecture-choice $proto://$host_and_port/guides/architecture-choice permanent;
-		rewrite ^/angular/best-practices/wire-backend $proto://$host_and_port/angular/guides/wire-backend permanent;
-		rewrite ^/angular/best-practices/architecture-choice $proto://$host_and_port/angular/guides/architecture-choice permanent;
-
+		rewrite ^(/angular)?/best-practices/(bundling-with-webpack|startup-time|images-optimisations) $proto://$host_and_port$1/performance-optimizations/$2 permanent;
+		rewrite ^(/angular)?/best-practices/(wire-backend|architecture-choice) $proto://$host_and_port$1/guides/$2 permanent;
+		
 		rewrite ^/integration-with-existing-ios-and-android-apps/extend-existing-android-app $proto://$host_and_port/guides/integration-with-existing-ios-and-android-apps/extend-existing-android-app permanent;
 		rewrite ^/integration-with-existing-ios-and-android-apps/extend-existing-ios-app $proto://$host_and_port/guides/integration-with-existing-ios-and-android-apps/extend-existing-ios-app permanent;
 		rewrite ^/angular/integration-with-existing-ios-and-android-apps/extend-existing-android-app $proto://$host_and_port/angular/guides/integration-with-existing-ios-and-android-apps/extend-existing-android-app permanent;
@@ -183,7 +143,7 @@ http {
 		
 		# Redirect the Angular Groceries tutorial to proper "Get Started" subsections
 		rewrite ^/(angular|start)/tutorial/ng-chapter-\d$ $proto://$host_and_port/angular/start/introduction permanent;
-		rewrite ^/tutorial/ng-chapter-\d$ $proto://$host_and_port/angular/start/introduction permanent;
+		rewrite ^/tutorial/ng-chapter-\d$ $proto://$host_and_port/start/introduction permanent;
 		rewrite ^/start/hello-world/ng-chapter-0 $proto://$host_and_port/angular/start/introduction permanent;
 		rewrite ^/start/hello-world/ng-chapter-1 $proto://$host_and_port/angular/start/introduction permanent;
 		rewrite ^/angular/start/hello-world/ng-chapter-0 $proto://$host_and_port/angular/start/introduction permanent;

--- a/build/nginx.conf
+++ b/build/nginx.conf
@@ -90,11 +90,13 @@ http {
 		# Redirect Chrome DevTools article
 		rewrite ^/tooling/chrome-devtools $proto://$host_and_port/tooling/debugging/chrome-devtools permanent;
 		rewrite ^/tooling/app-templates $proto://$host_and_port/app-and-screen-templates/app-templates permanent;
+		rewrite ^/angular/tooling/chrome-devtools $proto://$host_and_port/angular/tooling/debugging/chrome-devtools permanent;
+		rewrite ^/angular/tooling/app-templates $proto://$host_and_port/angular/app-and-screen-templates/app-templates permanent;
 
 		# Redirect Layout containers article
 		rewrite ^/ui/layout-containers $proto://$host_and_port/ui/layouts/layout-containers permanent;
 		rewrite ^/angular/ui/layout-containers $proto://$host_and_port/angular/ui/layouts/layout-containers permanent;
-		rewrite ^/angular/layouts $proto://$host_and_port/angular/ui/layouts/layouts permanent;
+		rewrite ^/angular/ui/layouts $proto://$host_and_port/angular/ui/layouts/layouts permanent;
 
 		# Redirect publishing related articles
 		rewrite ^/publishing/android-abi-split $proto://$host_and_port/tooling/publishing/android-abi-split permanent;
@@ -102,6 +104,12 @@ http {
 		rewrite ^/publishing/publishing-ios-apps $proto://$host_and_port/tooling/publishing/publishing-ios-apps permanent;
 		rewrite ^/publishing/creating-launch-screens-ios $proto://$host_and_port/tooling/publishing/creating-launch-screens-ios permanent;
 		rewrite ^/publishing/creating-launch-screens-android $proto://$host_and_port/tooling/publishing/creating-launch-screens-android permanent;
+		
+		rewrite ^/angular/publishing/android-abi-split $proto://$host_and_port/angular/tooling/publishing/android-abi-split permanent;
+		rewrite ^/angular/publishing/publishing-android-apps $proto://$host_and_port/angular/tooling/publishing/publishing-android-apps permanent;
+		rewrite ^/angular/publishing/publishing-ios-apps $proto://$host_and_port/angular/tooling/publishing/publishing-ios-apps permanent;
+		rewrite ^/angular/publishing/creating-launch-screens-ios $proto://$host_and_port/angular/tooling/publishing/creating-launch-screens-ios permanent;
+		rewrite ^/angular/publishing/creating-launch-screens-android $proto://$host_and_port/angular/tooling/publishing/creating-launch-screens-android permanent;
 
 		# Redirect base Angular link
 		rewrite ^/angular$ $proto://$host_and_port/angular/start/introduction permanent;

--- a/build/nginx.conf
+++ b/build/nginx.conf
@@ -73,8 +73,7 @@ http {
 		rewrite ^(/angular)?/runtimes/require$ $proto://$host_and_port$1/core-concepts/commonjs-modules permanent;
 		
 		# Redirect CLI docs under Tooling
-		rewrite ^/docs-cli/(.*) $proto://$host_and_port/tooling/docs-cli/$1 permanent;
-		rewrite ^/angular/docs-cli/(.*) $proto://$host_and_port/angular/stooling/docs-cli/$1 permanent;
+		rewrite ^(/angular)?/docs-cli/(.*) $proto://$host_and_port$1/tooling/docs-cli/$1 permanent;
 
 		# Redirect the Cookbook under UI Widgets
 		rewrite ^/cookbook/ui/layouts/(.*) $proto://$host_and_port/ui/layouts/layout-containers permanent;
@@ -88,29 +87,20 @@ http {
 		rewrite ^/start/how-it-works $proto://$host_and_port/core-concepts/technical-overview permanent;
 
 		# Redirect Chrome DevTools article
-		rewrite ^/tooling/chrome-devtools $proto://$host_and_port/tooling/debugging/chrome-devtools permanent;
-		rewrite ^/tooling/app-templates $proto://$host_and_port/app-and-screen-templates/app-templates permanent;
-		rewrite ^/angular/tooling/chrome-devtools $proto://$host_and_port/angular/tooling/debugging/chrome-devtools permanent;
-		rewrite ^/angular/tooling/app-templates $proto://$host_and_port/angular/app-and-screen-templates/app-templates permanent;
+		rewrite ^(/angular)?/tooling/chrome-devtools $proto://$host_and_port$1/tooling/debugging/chrome-devtools permanent;
+		rewrite ^(/angular)?/tooling/app-templates $proto://$host_and_port$1/app-and-screen-templates/app-templates permanent;
 
 		# Redirect Layout containers article
-		rewrite ^/ui/layout-containers $proto://$host_and_port/ui/layouts/layout-containers permanent;
-		rewrite ^/angular/ui/layout-containers $proto://$host_and_port/angular/ui/layouts/layout-containers permanent;
-		rewrite ^/angular/ui/layouts $proto://$host_and_port/angular/ui/layouts/layouts permanent;
+		rewrite ^(/angular)?/ui/layout-containers $proto://$host_and_port$1/ui/layouts/layout-containers permanent;
+		rewrite ^(/angular)?/ui/layouts $proto://$host_and_port$1/angular/ui/layouts/layouts permanent;
 
 		# Redirect publishing related articles
-		rewrite ^/publishing/android-abi-split $proto://$host_and_port/tooling/publishing/android-abi-split permanent;
-		rewrite ^/publishing/publishing-android-apps $proto://$host_and_port/tooling/publishing/publishing-android-apps permanent;
-		rewrite ^/publishing/publishing-ios-apps $proto://$host_and_port/tooling/publishing/publishing-ios-apps permanent;
-		rewrite ^/publishing/creating-launch-screens-ios $proto://$host_and_port/tooling/publishing/creating-launch-screens-ios permanent;
-		rewrite ^/publishing/creating-launch-screens-android $proto://$host_and_port/tooling/publishing/creating-launch-screens-android permanent;
+		rewrite ^(/angular)?/publishing/android-abi-split $proto://$host_and_port$1/tooling/publishing/android-abi-split permanent;
+		rewrite ^(/angular)?/publishing/publishing-android-apps $proto://$host_and_port$1/tooling/publishing/publishing-android-apps permanent;
+		rewrite ^(/angular)?/publishing/publishing-ios-apps $proto://$host_and_port$1/tooling/publishing/publishing-ios-apps permanent;
+		rewrite ^(/angular)?/publishing/creating-launch-screens-ios $proto://$host_and_port$1/tooling/publishing/creating-launch-screens-ios permanent;
+		rewrite ^(/angular)?/publishing/creating-launch-screens-android $proto://$host_and_port$1/tooling/publishing/creating-launch-screens-android permanent;
 		
-		rewrite ^/angular/publishing/android-abi-split $proto://$host_and_port/angular/tooling/publishing/android-abi-split permanent;
-		rewrite ^/angular/publishing/publishing-android-apps $proto://$host_and_port/angular/tooling/publishing/publishing-android-apps permanent;
-		rewrite ^/angular/publishing/publishing-ios-apps $proto://$host_and_port/angular/tooling/publishing/publishing-ios-apps permanent;
-		rewrite ^/angular/publishing/creating-launch-screens-ios $proto://$host_and_port/angular/tooling/publishing/creating-launch-screens-ios permanent;
-		rewrite ^/angular/publishing/creating-launch-screens-android $proto://$host_and_port/angular/tooling/publishing/creating-launch-screens-android permanent;
-
 		# Redirect base Angular link
 		rewrite ^/angular$ $proto://$host_and_port/angular/start/introduction permanent;
 		rewrite ^/angular/start/how-it-works$ $proto://$host_and_port/angular/core-concepts/technical-overview permanent;
@@ -142,21 +132,17 @@ http {
 		rewrite ^(/angular)?/best-practices/(bundling-with-webpack|startup-time|images-optimisations) $proto://$host_and_port$1/performance-optimizations/$2 permanent;
 		rewrite ^(/angular)?/best-practices/(wire-backend|architecture-choice) $proto://$host_and_port$1/guides/$2 permanent;
 		
-		rewrite ^/integration-with-existing-ios-and-android-apps/extend-existing-android-app $proto://$host_and_port/guides/integration-with-existing-ios-and-android-apps/extend-existing-android-app permanent;
-		rewrite ^/integration-with-existing-ios-and-android-apps/extend-existing-ios-app $proto://$host_and_port/guides/integration-with-existing-ios-and-android-apps/extend-existing-ios-app permanent;
-		rewrite ^/angular/integration-with-existing-ios-and-android-apps/extend-existing-android-app $proto://$host_and_port/angular/guides/integration-with-existing-ios-and-android-apps/extend-existing-android-app permanent;
-		rewrite ^/angular/integration-with-existing-ios-and-android-apps/extend-existing-ios-app $proto://$host_and_port/angular/guides/integration-with-existing-ios-and-android-apps/extend-existing-ios-app permanent;
-
+		rewrite ^(/angular)?/integration-with-existing-ios-and-android-apps/extend-existing-android-app $proto://$host_and_port$1/guides/integration-with-existing-ios-and-android-apps/extend-existing-android-app permanent;
+		rewrite ^(/angular)?/integration-with-existing-ios-and-android-apps/extend-existing-ios-app $proto://$host_and_port$1/guides/integration-with-existing-ios-and-android-apps/extend-existing-ios-app permanent;
+	
 		rewrite ^/angular/best-practices/bundling-with-webpack $proto://$host_and_port/angular/performance-optimizations/bundling-with-webpack permanent;
 		
 		# Redirect the Angular Groceries tutorial to proper "Get Started" subsections
 		rewrite ^/(angular|start)/tutorial/ng-chapter-\d$ $proto://$host_and_port/angular/start/introduction permanent;
 		rewrite ^/tutorial/ng-chapter-\d$ $proto://$host_and_port/start/introduction permanent;
-		rewrite ^/start/hello-world/ng-chapter-0 $proto://$host_and_port/angular/start/introduction permanent;
-		rewrite ^/start/hello-world/ng-chapter-1 $proto://$host_and_port/angular/start/introduction permanent;
-		rewrite ^/angular/start/hello-world/ng-chapter-0 $proto://$host_and_port/angular/start/introduction permanent;
-		rewrite ^/angular/start/hello-world/ng-chapter-1 $proto://$host_and_port/angular/start/introduction permanent;
-
+		rewrite ^(/angular)?/start/hello-world/ng-chapter-0 $proto://$host_and_port$1/angular/start/introduction permanent;
+		rewrite ^(/angular)?/start/hello-world/ng-chapter-1 $proto://$host_and_port$1/angular/start/introduction permanent;
+		
 		# Redirect the JavaScript Groceries tutorial links
 		rewrite ^/start/getting-started $proto://$host_and_port/start/introduction permanent;
 		rewrite ^/start/tutorial/chapter-\d$ $proto://$host_and_port/start/introduction permanent;

--- a/build/nginx.conf
+++ b/build/nginx.conf
@@ -71,6 +71,10 @@ http {
 		rewrite ^/angular/runtimes/android/(.*) $proto://$host_and_port/angular/core-concepts/android-runtime/$1 permanent;
 		rewrite ^/runtimes/ios/(.*) $proto://$host_and_port/core-concepts/ios-runtime/$1 permanent;
 		rewrite ^/angular/runtimes/ios/(.*) $proto://$host_and_port/angular/core-concepts/ios-runtime/$1 permanent;
+		rewrite ^/runtimes/ios/how-to/Use-Native-Libraries $proto://$host_and_port/plugins/Use-Native-iOS-Libraries permanent;
+		rewrite ^/angular/runtimes/ios/how-to/Use-Native-Libraries $proto://$host_and_port/angular/plugins/Use-Native-iOS-Libraries permanent;
+		rewrite ^/runtimes/require $proto://$host_and_port/core-concepts/commonjs-modules permanent;
+		rewrite ^/angular/runtimes/require $proto://$host_and_port/angular/core-concepts/commonjs-modules permanent;
 		
 		# Redirect CLI docs under Tooling
 		rewrite ^/docs-cli/(.*) $proto://$host_and_port/tooling/docs-cli/$1 permanent;
@@ -89,36 +93,51 @@ http {
 
 		# Redirect Chrome DevTools article
 		rewrite ^/tooling/chrome-devtools $proto://$host_and_port/tooling/debugging/chrome-devtools permanent;
+		rewrite ^/tooling/app-templates $proto://$host_and_port/app-and-screen-templates/app-templates permanent;
 
 		# Redirect Layout containers article
 		rewrite ^/ui/layout-containers $proto://$host_and_port/ui/layouts/layout-containers permanent;
 		rewrite ^/angular/ui/layout-containers $proto://$host_and_port/angular/ui/layouts/layout-containers permanent;
+		rewrite ^/angular/layouts $proto://$host_and_port/angular/ui/layouts/layouts permanent;
 
 		# Redirect publishing related articles
 		rewrite ^/publishing/android-abi-split $proto://$host_and_port/tooling/publishing/android-abi-split permanent;
 		rewrite ^/publishing/publishing-android-apps $proto://$host_and_port/tooling/publishing/publishing-android-apps permanent;
 		rewrite ^/publishing/publishing-ios-apps $proto://$host_and_port/tooling/publishing/publishing-ios-apps permanent;
+		rewrite ^/publishing/creating-launch-screens-ios $proto://$host_and_port/tooling/publishing/creating-launch-screens-ios permanent;
+		rewrite ^/publishing/creating-launch-screens-android $proto://$host_and_port/tooling/publishing/creating-launch-screens-android permanent;
 
 		# Redirect base Angular link
 		rewrite ^/angular$ $proto://$host_and_port/angular/start/introduction permanent;
+		rewrite ^/angular/start/how-it-works$ $proto://$host_and_port/angular/core-concepts/technical-overview permanent;
+		rewrite ^/angular/start/troubleshooting$ $proto://$host_and_port/angular/troubleshooting permanent;
+
+		rewrite ^/start/troubleshooting$ $proto://$host_and_port/troubleshooting permanent;
+
 
 		# Redirect Angular Code Samples to UI Widgets
 		rewrite ^/angular/code-samples/ui/(.*) $proto://$host_and_port/angular/ui/ng-ui-widgets/$1 permanent;
 		rewrite ^/angular/code-samples/ui/layouts $proto://$host_and_port/angular/ui/layouts/layout-containers permanent;
+		rewrite ^/angular/code-samples/overview $proto://$host_and_port/angular/ui/ng-ui-widgets/action-bar permanent; // page doesn't exist, redirect to first UI widget
+		rewrite ^/angular/code-samples/modal-page $proto://$host_and_port/angular/ui/ng-ui-widgets/modal-page permanent;
+
+		rewrite ^/angular/code-samples/camera $proto://$host_and_port/angular/ng-hardware-access/camera permanent;
+		rewrite ^/angular/code-samples/location $proto://$host_and_port/angular/ng-hardware-access/location permanent;
+
 		# rewrite ^/angular/ui/(.*) $proto://$host_and_port/angular/ui/components/ permanent;
 
 		# Redirect Angular Code Samples (that were outside UI section)
-		rewrite ^/angular/cookbook/application $proto://$host_and_port/angular/ng-framework-modules/application permanent;
-		rewrite ^/angular/cookbook/application-settings $proto://$host_and_port/angular/ng-framework-modules/application-settings permanent;
-		rewrite ^/angular/cookbook/color $proto://$host_and_port/angular/ng-framework-modules/color permanent;
-		rewrite ^/angular/cookbook/connectivity $proto://$host_and_port/angular/ng-framework-modules/connectivity permanent;
-		rewrite ^/angular/cookbook/file-system $proto://$host_and_port/angular/ng-framework-modules/file-system permanent;
-		rewrite ^/angular/cookbook/fps-meter $proto://$host_and_port/angular/ng-framework-modules/fps-meter permanent;
-		rewrite ^/angular/cookbook/http $proto://$host_and_port/angular/ng-framework-modules/http permanent;
-		rewrite ^/angular/cookbook/platform $proto://$host_and_port/angular/ng-framework-modules/platform permanent;
-		rewrite ^/angular/cookbook/routing $proto://$host_and_port/angular/ng-framework-modules/routing permanent;
-		rewrite ^/angular/cookbook/timer $proto://$host_and_port/angular/ng-framework-modules/timer permanent;
-		rewrite ^/angular/cookbook/trace $proto://$host_and_port/angular/ng-framework-modules/trace permanent;
+		rewrite ^/angular/(cookbook|code-samples)/application $proto://$host_and_port/angular/ng-framework-modules/application permanent;
+		rewrite ^/angular/(cookbook|code-samples)/application-settings $proto://$host_and_port/angular/ng-framework-modules/application-settings permanent;
+		rewrite ^/angular/(cookbook|code-samples)/color $proto://$host_and_port/angular/ng-framework-modules/color permanent;
+		rewrite ^/angular/(cookbook|code-samples)/connectivity $proto://$host_and_port/angular/ng-framework-modules/connectivity permanent;
+		rewrite ^/angular/(cookbook|code-samples)/file-system $proto://$host_and_port/angular/ng-framework-modules/file-system permanent;
+		rewrite ^/angular/(cookbook|code-samples)/fps-meter $proto://$host_and_port/angular/ng-framework-modules/fps-meter permanent;
+		rewrite ^/angular/(cookbook|code-samples)/http $proto://$host_and_port/angular/ng-framework-modules/http permanent;
+		rewrite ^/angular/(cookbook|code-samples)/platform $proto://$host_and_port/angular/ng-framework-modules/platform permanent;
+		rewrite ^/angular/(cookbook|code-samples)/routing $proto://$host_and_port/angular/ng-framework-modules/routing permanent;
+		rewrite ^/angular/(cookbook|code-samples)/timer $proto://$host_and_port/angular/ng-framework-modules/timer permanent;
+		rewrite ^/angular/(cookbook|code-samples)/trace $proto://$host_and_port/angular/ng-framework-modules/trace permanent;
 
 		# Redirect the Cookbook under Framework Modules
 		rewrite ^/cookbook/trace $proto://$host_and_port/ns-framework-modules/trace permanent;
@@ -132,7 +151,8 @@ http {
 		rewrite ^/cookbook/data/virtual-array $proto://$host_and_port/ns-framework-modules/virtual-array permanent;
 		rewrite ^/cookbook/fetch $proto://$host_and_port/ns-framework-modules/fetch permanent;
 		rewrite ^/cookbook/file-system $proto://$host_and_port/ns-framework-modules/file-system permanent;
-		rewrite ^/cookbook/formatted-string $proto://$host_and_port/ns-framework-modules/formatted-string permanent;
+		rewrite ^/cookbook/formatted-string $proto://$host_and_port/ui/ns-ui-widgets/formatted-string permanent;
+		rewrite ^/cookbook/formatted-string-ng $proto://$host_and_port/angular/ui/ng-ui-widgets/formatted-string permanent;
 		rewrite ^/cookbook/fps-meter $proto://$host_and_port/ns-framework-modules/fps-meter permanent;
 		rewrite ^/cookbook/http $proto://$host_and_port/ns-framework-modules/http permanent;
 		rewrite ^/cookbook/image-source $proto://$host_and_port/ns-framework-modules/image-source permanent;
@@ -142,11 +162,28 @@ http {
 
 		# Redirect the Best Practices articles
 		rewrite ^/best-practices/bundling-with-webpack $proto://$host_and_port/performance-optimizations/bundling-with-webpack permanent;
+		rewrite ^/best-practices/startup-times $proto://$host_and_port/performance-optimizations/startup-times permanent;
+		rewrite ^/best-practices/images-optimisations $proto://$host_and_port/performance-optimizations/images-optimisations permanent;
 		rewrite ^/angular/best-practices/bundling-with-webpack $proto://$host_and_port/angular/performance-optimizations/bundling-with-webpack permanent;
-		rewrite ^/best-practices/images-optimisations $proto://$host_and_port/angular/performance-optimizations/images-optimisations permanent;
+		rewrite ^/angular/best-practices/startup-times $proto://$host_and_port/angular/performance-optimizations/startup-times permanent;
+		rewrite ^/angular/best-practices/images-optimisations $proto://$host_and_port/angular/performance-optimizations/images-optimisations permanent;
 
+
+		rewrite ^/best-practices/wire-backend $proto://$host_and_port/guides/wire-backend permanent;
+		rewrite ^/best-practices/architecture-choice $proto://$host_and_port/guides/architecture-choice permanent;
+		rewrite ^/angular/best-practices/wire-backend $proto://$host_and_port/angular/guides/wire-backend permanent;
+		rewrite ^/angular/best-practices/architecture-choice $proto://$host_and_port/angular/guides/architecture-choice permanent;
+
+		rewrite ^/integration-with-existing-ios-and-android-apps/extend-existing-android-app $proto://$host_and_port/guides/integration-with-existing-ios-and-android-apps/extend-existing-android-app permanent;
+		rewrite ^/integration-with-existing-ios-and-android-apps/extend-existing-ios-app $proto://$host_and_port/guides/integration-with-existing-ios-and-android-apps/extend-existing-ios-app permanent;
+		rewrite ^/angular/integration-with-existing-ios-and-android-apps/extend-existing-android-app $proto://$host_and_port/angular/guides/integration-with-existing-ios-and-android-apps/extend-existing-android-app permanent;
+		rewrite ^/angular/integration-with-existing-ios-and-android-apps/extend-existing-ios-app $proto://$host_and_port/angular/guides/integration-with-existing-ios-and-android-apps/extend-existing-ios-app permanent;
+
+		rewrite ^/angular/best-practices/bundling-with-webpack $proto://$host_and_port/angular/performance-optimizations/bundling-with-webpack permanent;
+		
 		# Redirect the Angular Groceries tutorial to proper "Get Started" subsections
 		rewrite ^/(angular|start)/tutorial/ng-chapter-\d$ $proto://$host_and_port/angular/start/introduction permanent;
+		rewrite ^/tutorial/ng-chapter-\d$ $proto://$host_and_port/angular/start/introduction permanent;
 		rewrite ^/start/hello-world/ng-chapter-0 $proto://$host_and_port/angular/start/introduction permanent;
 		rewrite ^/start/hello-world/ng-chapter-1 $proto://$host_and_port/angular/start/introduction permanent;
 		rewrite ^/angular/start/hello-world/ng-chapter-0 $proto://$host_and_port/angular/start/introduction permanent;


### PR DESCRIPTION
Add permanent redirects for the broken links below + some which are not in the list below but were in the same sections as them

docs.nativescript.org/tutorial/ng-chapter-0
docs.nativescript.org/tutorial/ng-chapter-1
docs.nativescript.org/tutorial/ng-chapter-2
docs.nativescript.org/tutorial/ng-chapter-4
docs.nativescript.org/tutorial/ng-chapter-3

docs.nativescript.org/publishing/creating-launch-screens-ios
docs.nativescript.org/publishing/creating-launch-screens-android

docs.nativescript.org/tooling/app-templates

docs.nativescript.org/angular/code-samples/overview
docs.nativescript.org/angular/code-samples/modal-page
docs.nativescript.org/angular/code-samples/http
docs.nativescript.org/angular/code-samples/routing
docs.nativescript.org/angular/code-samples/file-system
docs.nativescript.org/angular/code-samples/application
docs.nativescript.org/angular/code-samples/camera
docs.nativescript.org/angular/code-samples/application-settings

docs.nativescript.org/angular/ui/layouts

docs.nativescript.org/angular/start/how-it-works
docs.nativescript.org/angular/start/troubleshooting

docs.nativescript.org/start/troubleshooting

docs.nativescript.org/best-practices/startup-times
docs.nativescript.org/best-practices/wire-backend
docs.nativescript.org/best-practices/architecture-choice

docs.nativescript.org/angular/best-practices/wire-backend
docs.nativescript.org/angular/best-practices/startup-times

docs.nativescript.org/integration-with-existing-ios-and-android-apps/extend-existing-android-app

docs.nativescript.org/runtimes/ios/how-to/Use-Native-Libraries
docs.nativescript.org/runtimes/require

docs.nativescript.org/cookbook/formatted-string-ng