### PR TITLE
docs: delete obsolete paragraph

### DIFF
--- a/docs/start/introduction.md
+++ b/docs/start/introduction.md
@@ -18,8 +18,6 @@ NativeScript is how you build cross-platform, native iOS and Android apps withou
 NativeScript doesn’t require [Angular](https://angular.io/), but it’s even better when you use it. You can fully reuse skills and code from the web to build beautiful, high performance native mobile apps without web views. NativeScript features deep integration with Angular, the latest and greatest (and fastest) JavaScript framework. Open source and backed by Progress.
 {% endangular %}
 
-> **TIP**: Looking for guided introduction to NativeScript? Join us for a [30-minute getting-started webinar](https://register.gotowebinar.com/register/8013085005086231299), where you’ll learn the basics of NativeScript, and have the chance to ask questions.
-
 Ready to get started developing with NativeScript? Here are your next steps.
 
 ## Step #1: NativeScript Playground


### PR DESCRIPTION
Following the link to the webinar merely produces a page saying the webinar has ended. This makes the paragraph useless. If the webinar were recorded and available, then the paragraph would be useful, but it would need to omit the statement that the user will have an opportunity to ask questions.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] If there is an issue related with this PR, point it out here.

## What is the current state of the documentation article?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The page contains an obsolete paragraph.

## What is the new state of the documentation article?
<!-- Describe the changes. -->
The obsolete paragraph is no longer present.

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

