### PR TITLE
docs: router-outlet vs page-router-outlet

### DIFF
--- a/docs/core-concepts/angular-navigation.md
+++ b/docs/core-concepts/angular-navigation.md
@@ -90,6 +90,16 @@ Note that we can now use the **Back button** and the **NavigationBar** to naviga
 
 It is possible to nest `<router-outlet>` component inside `<page-router-outlet>` or another `<router-outlet>`.
 
+### Using router-outlet Instead of page-router-outlet
+
+In some cases, you might want to create an application without using `page-router-outlet`. To achieve that with nativescript-angular version 6 and above an additional bootstrap parameter called `createFrameOnBootstrap` must be provided to create a `Frame` during the bootstrapping.
+
+app/main.ts
+```TypeScript
+platformNativeScriptDynamic({ createFrameOnBootstrap: true }).bootstrapModule(AppModule);
+
+```
+
 ## Navigation Options
 
 You can define the trigger in your application declaratively - using the `nsRouterLink` directive in your markup. Or you can do it through code - by injecting  the `RouterExtensions` class and using its methods:
@@ -190,13 +200,3 @@ So, instead of:
 
 You do:
 {%snippet router-params-page-route%}
-
-## Application Without Page Router Outlet
-
-In some cases, you might want to create an application without using `page-router-outlet`. To achieve that with nativescript-angular version 6 and above an additional bootstrap parameter called `createFrameOnBootstrap` must be provided to create a `Frame` during the bootstrapping.
-
-app/main.ts
-```TypeScript
-platformNativeScriptDynamic({ createFrameOnBootstrap: true }).bootstrapModule(AppModule);
-
-```


### PR DESCRIPTION
Move important details about router-outlet next to relevant information in the documentation page.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.


## What is the current state of the documentation article?
Information about using router-outlet over page-router-outlet is tucked away at the bottom of the page.

## What is the new state of the documentation article?
Move important details about router-outlet next to relevant information in the documentation apge.

Fixes/Implements/Closes #[Issue Number].
https://github.com/NativeScript/docs/issues/1206


