### PR TITLE
Update forum references with Stack Overflow

### DIFF
--- a/build/_includes/footer.html
+++ b/build/_includes/footer.html
@@ -90,7 +90,7 @@
             <div>
                 <h5 class="-allcaps">Support</h5>
                 <ul class="List0 HighlightList -ff-prim">
-                        <li><a href="https://discourse.nativescript.org">Community Forums</a></li>
+                        <li><a href="https://stackoverflow.com/questions/tagged/nativescript">Stack Overflow</a></li>
                         <li><a href="{{site.headerbaseurl}}/faq">FAQs</a></li>
                         <li><a href="http://tinyurl.com/nativeScriptSlack">Slack</a></li>
                         <li><a href="{{site.headerbaseurl}}/support">Developer Support</a></li>

--- a/build/_includes/header.html
+++ b/build/_includes/header.html
@@ -36,7 +36,7 @@
         <li>
             <span>Support</span>
             <ul>
-                <li><a href="https://discourse.nativescript.org">Community Forums</a></li>
+                <li><a href="https://stackoverflow.com/questions/tagged/nativescript">Stack Overflow</a></li>
                 <li><a href="{{site.headerbaseurl}}/faq">FAQs</a></li>
                 <li><a href="http://tinyurl.com/nativeScriptSlack" target="_blank">Slack</a></li>
                 <li><a href="{{site.headerbaseurl}}/developer-support">Developer Support</a></li>

--- a/build/_includes/improvethis.html
+++ b/build/_includes/improvethis.html
@@ -1,4 +1,4 @@
 <div class="right-nav__links">
-  <a class="ns-button" href="https://discourse.nativescript.org/" target="_blank">Ask the community</a>
+  <a class="ns-button" href="https://stackoverflow.com/questions/tagged/nativescript" target="_blank">Ask the community</a>
   <a class="{{ page.improvethisvisibilityclass }}" href="{{ page.improvethisurl }}" target="_blank"><i class="fal fa-pencil"></i> Improve this article</a>
 </div>

--- a/docs/core-concepts/plugins.md
+++ b/docs/core-concepts/plugins.md
@@ -18,7 +18,7 @@ Because NativeScript plugins are npm packages, you can find NativeScript plugins
 
 The NativeScript team also maintains an [official marketplace](http://market.nativescript.org/), which displays a filtered list of NativeScript-related plugins from npm. A search for “accelerometer” on the plugins marketplace will point you at the plugin you need.
 
-If you don’t find a plugin, you need to try asking for help on the [NativeScript community forum](https://discourse.nativescript.org/c/plugins). The NativeScript team and community may be able to help find what you’re looking for.
+If you can't find a plugin, try asking for help on [Stack Overflow](https://stackoverflow.com/questions/tagged/nativescript). The NativeScript team and community may be able to help find what you’re looking for.
 
 Also, make sure to look through the [NativeScript core modules](https://docs.nativescript.org/core-concepts/modules), which ship as a dependency of every NativeScript app. There’s a chance that the functionality you need is built in. If you’re still not finding what you need, you can request the plugin as an idea on the [NativeScript community forum](https://discourse.nativescript.org/c/plugins), or you can take a stab at [building the plugin yourself](/plugins/building-plugins/).
 

--- a/docs/get-support.md
+++ b/docs/get-support.md
@@ -17,7 +17,7 @@ publish: true
 
 The NativeScript framework has a vibrant community that’s here to help when you run into problems.
 
-If you hit an issue, start by seeing if anyone else has reported the problem on [the NativeScript community forum](http://forum.nativescript.org/). If you can’t find any information, try creating a new forum topic with any details needed to recreate the issue.
+If you hit an issue, start by seeing if anyone else has reported the problem on [Stack Overflow](https://stackoverflow.com/questions/tagged/nativescript) or [the deprecated NativeScript community forum](https://discourse.nativescript.org/). If you can’t find any information, try creating a new question on Stack Overflow with any details needed to recreate the issue.
 
 If you’ve found an issue with the NativeScript framework itself, please report the problem in the appropriate GitHub repository.
 

--- a/docs/performance-optimizations/startup-times.md
+++ b/docs/performance-optimizations/startup-times.md
@@ -52,7 +52,7 @@ Or
 tns run ios --bundle
 ```
 
-> **NOTE**: If you’re having trouble enabling webpack in your own apps, feel free to reach out for help on the [NativeScript community forum](https://discourse.nativescript.org/).
+> **NOTE**: If you’re having trouble enabling webpack in your own apps, feel free to reach out for help on [Stack Overflow](https://stackoverflow.com/questions/tagged/nativescript).
 
 To give you a sense of how big of a difference webpack makes, let’s look at some before and after videos of applying webpack builds to the [NativeScript Groceries sample](https://github.com/nativescript/sample-Groceries). Here’s what Groceries looks like if you start it _without_ using webpack.
 

--- a/docs/plugins/building-plugins.md
+++ b/docs/plugins/building-plugins.md
@@ -298,4 +298,4 @@ And these are just the basics. The plugin seed supports more advanced workflows 
 - [Adding unit tests]({% slug plugin-unit-tests %})
 - [Setting up Travis CI](https://github.com/NativeScript/nativescript-plugin-seed#travisci)
 
-If you run into any problems during your plugin development, reach out using the [NativeScript community forum](https://discourse.nativescript.org/). And if you’d like to chat with other NativeScript plugin authors, sign up for the [NativeScript community chat](http://developer.telerik.com/wp-login.php?action=slack-invitation) and join us in the #plugins channel.
+If you run into any problems during your plugin development, reach out on [Stack Overflow](https://stackoverflow.com/questions/tagged/nativescript). And if you’d like to chat with other NativeScript plugin authors, sign up for the [NativeScript slack](http://developer.telerik.com/wp-login.php?action=slack-invitation) and join us in the #plugins channel.

--- a/docs/sidekick/user-guide/enterprise-auth/intro.md
+++ b/docs/sidekick/user-guide/enterprise-auth/intro.md
@@ -64,7 +64,7 @@ When you tap the **Log in** button, if all went well, you should be prompted to 
 
 ![](../../img/enterprise-auth/app-auth-screen.png)
 
-> **NOTE**: Configuring enterprise authentication providers is very tricky. If you’re not seeing your auth screen as expected, or if you hit problems at any time throughout the process, feel free to [reach out on the NativeScript community forum](https://discourse.nativescript.org/c/Sidekick).
+> **NOTE**: Configuring enterprise authentication providers is very tricky. If you’re not seeing your auth screen as expected, or if you hit problems at any time throughout the process, feel free to [reach out on Stack Overflow](https://stackoverflow.com/questions/tagged/nativescript).
 
 And that’s it! You’ve now successfully built an app that can connect to an enterprise authentication provider.
 

--- a/docs/start/cli-basics.md
+++ b/docs/start/cli-basics.md
@@ -69,7 +69,7 @@ tns run android
 ```
 
 > **NOTE**:
-> * If you get an error at this point you likely haven’t completed the [NativeScript CLI installation instructions](/start/quick-setup). If you’ve gone through the instructions and are still stuck, try asking for help in the [NativeScript community forum](http://forum.nativescript.org/).
+> * If you get an error at this point you likely haven’t completed the [NativeScript CLI installation instructions](/start/quick-setup). If you’ve gone through the instructions and are still stuck, try asking for help on [Stack Overflow](https://stackoverflow.com/questions/tagged/nativescript).
 > * You must have at least one AVD (Android Virtual Device) configured on your development machine for this command to run your app up on an Android emulator. If you don’t have one installed currently go ahead and [set one up now](/tooling/android-virtual-devices).
 
 The `run` command will take a few seconds to complete, as the NativeScript CLI will actually be building and deploying a native Android application. When the command finishes the native emulator will open and you will see your app:

--- a/docs/start/quick-setup.md
+++ b/docs/start/quick-setup.md
@@ -54,7 +54,7 @@ $ tns
 NativeScript builds truly native iOS and Android apps, and as such, each target platform needs setting up on the development machine. To ease the pain of installing all of these requirements manually, the `tns` command provides quick-start scripts for Windows and macOS. Let’s look at how they work.
 
 > **TIP**:
-> * Setting up your machine for native development can be tricky, especially if you’re new to mobile development. If you get stuck, or if you have questions while going through these instructions, the [forum](https://discourse.nativescript.org/c/getting-started) is a great place to get help.
+> * Setting up your machine for native development can be tricky, especially if you’re new to mobile development. If you get stuck, or if you have questions while going through these instructions, [Stack Overflow](https://stackoverflow.com/questions/tagged/nativescript) is a great place to get help.
 > * If you’re not comfortable with a script automatically installing dependencies on your development machine, or if you’re on Linux, refer to one of the advanced setup guides below for details on manually installing the iOS and Android dependencies.
 >     * [Advanced setup: Windows](/start/ns-setup-win)
 >     * [Advanced setup: macOS](/start/ns-setup-os-x)


### PR DESCRIPTION
With the community forum being deprecated at the end of September, this PR updates forum links with [Stack Overflow](https://stackoverflow.com/questions/tagged/nativescript)