### PR TITLE
docs: Add meta description to more pages

### DIFF
--- a/docs/app-and-screen-templates/app-templates.md
+++ b/docs/app-and-screen-templates/app-templates.md
@@ -1,6 +1,6 @@
 ---
 title: NativeScript Application Templates
-description: List of the available application and screen templates used as a blueprint for a NativeScript mobile application.
+description: Learn more about the available application templates used as a blueprint for a NativeScript mobile application - SideDrawer, Tabs, Master-Detail
 position: 70
 slug: nativescript-application-templates
 ---

--- a/docs/app-and-screen-templates/creating-custom-templates.md
+++ b/docs/app-and-screen-templates/creating-custom-templates.md
@@ -1,6 +1,6 @@
 ---
 title: Create Custom Application Templates
-description: Guidelines for creating custom application templates
+description: Learn how to create your own template and the guidelines to follow
 position: 75
 slug: nativescript-create-custom-templates
 environment: nativescript

--- a/docs/code-sharing/build-process.md
+++ b/docs/code-sharing/build-process.md
@@ -1,6 +1,6 @@
 ---
 title: Build Process
-description: NativeScript Documentation - Code Sharing - Build Process
+description: Learn how to build the web and mobile parts of an Angular and NativeScript code-sharing project and how the build process works
 position: 40
 environment: angular
 ---

--- a/docs/code-sharing/code-splitting.md
+++ b/docs/code-sharing/code-splitting.md
@@ -1,6 +1,6 @@
 ---
 title: Code Splitting
-description: NativeScript Documentation - Code Sharing - Code Splitting
+description: Learn how to do code splitting in an Angular and NativeScript code-sharing project - define different markup for your web and mobile apps
 position: 50
 environment: angular
 ---

--- a/docs/code-sharing/creating-a-new-project.md
+++ b/docs/code-sharing/creating-a-new-project.md
@@ -1,6 +1,6 @@
 ---
 title: Creating a New Project
-description: NativeScript Documentation - Code Sharing - Creating a new project
+description: Learn how to create a new Angular and NativeScript code-sharing project
 position: 20
 environment: angular
 ---

--- a/docs/code-sharing/migrating-a-web-project.md
+++ b/docs/code-sharing/migrating-a-web-project.md
@@ -1,6 +1,6 @@
 ---
 title: Migrating a Web project
-description: NativeScript Documentation - Code Sharing - Migrating a Web project
+description: Learn how to migrate an existing Angular Web Project to Angular and NativeScript code-sharing project
 position: 30
 environment: angular
 ---

--- a/docs/code-sharing/platform-specific-components.md
+++ b/docs/code-sharing/platform-specific-components.md
@@ -1,6 +1,6 @@
 ---
 title: Platform-Specific Components
-description: NativeScript Documentation - Code Sharing - Platform-Specific Components
+description: Learn how to create platform-specific components in Angular and NativeScript code-sharing project
 position: 60
 environment: angular
 ---

--- a/docs/cookbook/formatted-string-ng.md
+++ b/docs/cookbook/formatted-string-ng.md
@@ -1,6 +1,6 @@
 ---
 title: Using formatted string
-description: How to use the FormattedString class in an Angular App
+description: Learn how to use the FormattedString class in an Angular app
 position: 2
 slug: formatted-string
 previous_url: /formatted-string

--- a/docs/cookbook/tab-view-ng.md
+++ b/docs/cookbook/tab-view-ng.md
@@ -1,6 +1,6 @@
 ---
 title: Tab View
-description: NativeScript for Angular Documentation - Using Tab View
+description: Learn how to use TabView class in an Angular app
 position: 5
 slug: tabview
 previous_url: /tabview


### PR DESCRIPTION
Add meta description to the pages in:
- app-and-screen-templates
- code-sharing
- cookbook