### PR TITLE
docs(angular/core concepts): update links pointing to angular docs

### DIFF
--- a/docs/core-concepts/angular-application-architecture.md
+++ b/docs/core-concepts/angular-application-architecture.md
@@ -41,7 +41,7 @@ Each component has two parts - the **component class** and the **component templ
 
 The class and the view communicate with each other using data binding and events.
 
-You can learn more about components on [angular.io](https://angular.io/docs/ts/latest/guide/architecture.html#!#components).
+You can learn more about components on [angular.io](https://angular.io/api/core/Component).
 
 There are almost no differences between creating component classes in Angular web apps and NativeScript apps.
 
@@ -49,7 +49,7 @@ There are almost no differences between creating component classes in Angular we
 The template defines the view of the component - what is actually rendered. 
 In NativeScript applications the template is defined with XML using [NativeScript UI elements]({% slug components %}). It is different from HTML. So instead of `<input>`, `<span>`, `<div>` etc. - we have `<text-field>`, `<label>` and layouts.
 
-The important thing is that although the elements are different - all of the [Angular’s template syntax](https://angular.io/docs/ts/latest/guide/template-syntax.html) works exactly the same. So you can still use template expressions, bindings, templates as well as all the built-in directives.
+The important thing is that although the elements are different - all of the [Angular’s template syntax](https://angular.io/guide/template-syntax) works exactly the same. So you can still use template expressions, bindings, templates as well as all the built-in directives.
 
 >When defining the template you can use both CamelCase and kebab-case. So, both `<StackLayout>` and `<stack-layout>` are valid inside a template definition. 
 
@@ -90,19 +90,19 @@ This topic is covered in depth in the [data binding article]({% slug data-bindin
 Directives allow you to create and attach behavior to the visual tree. There are three kinds of directives:
 
 * `Components` - We already talked about them. `Components` are actually directives which have their own template.
-* [Structural Directives](https://angular.io/docs/ts/latest/guide/structural-directives.html) - alter the visual tree by adding, removing or replacing elements. The most commonly used structural directives are [`*ngIf`](https://angular.io/docs/ts/latest/guide/displaying-data.html#!#ngIf) and [`*ngFor`](https://angular.io/docs/ts/latest/guide/displaying-data.html#!#ngFor).
-* [Attribute Directive](https://angular.io/docs/ts/latest/guide/attribute-directives.html) - change the appearance or behavior of UI elements. One of the most commonly used attribute directives is [`ngClass`](https://angular.io/docs/ts/latest/guide/template-syntax.html#!#ngClass).
+* [Structural Directives](https://angular.io/guide/structural-directives) - alter the visual tree by adding, removing or replacing elements. The most commonly used structural directives are [`*ngIf`](https://angular.io/guide/template-syntax#ngIf) and [`*ngFor`](https://angular.io/guide/template-syntax#ngFor).
+* [Attribute Directive](https://angular.io/guide/attribute-directives) - change the appearance or behavior of UI elements. One of the most commonly used attribute directives is [`ngClass`](https://angular.io/guide/template-syntax#ngClass).
 
 When it comes to NativeScript specifics - there are again almost no differences as far as directives are concerned. You are free to use all the built-in Angular directives; you’re also free to write your own.
 
 ## Dependency Injection
 
 Angular ships with its own dependency injection (DI for short) framework. It is extremely powerful and fully usable in NativeScript.
-You can read more about it on [angular.io](https://angular.io/docs/ts/latest/guide/dependency-injection.html).
+You can read more about it on [angular.io](https://angular.io/guide/dependency-injection).
 
 ## Navigation
 
-The navigation inside a NativeScript application is done with the [Angular Router](https://angular.io/docs/ts/latest/guide/router.html#). However, you can choose between two router-outlets:
+The navigation inside a NativeScript application is done with the [Angular Router](https://angular.io/guide/router). However, you can choose between two router-outlets:
 * `router-outlet` - the built in Angular router outlet. It replaces the content of the outlet with the templates of different component.
 * `page-router-outlet` - uses NativeScript [page navigation]({% slug navigation %}#pages). 
 

--- a/docs/core-concepts/angular-navigation.md
+++ b/docs/core-concepts/angular-navigation.md
@@ -12,7 +12,7 @@ In this article we will cover how to do navigation in NativeScript application u
 
 ## Router
 
-In an Angular application navigation is done using the **Angular Component Router**. You can check [this detailed guide on how to use the router](https://angular.io/docs/ts/latest/guide/router.html). From here on we are going to assume that you are familiar with the basic concepts and concentrate on the specifics when doing navigation with Angular inside a NativeScript app.
+In an Angular application navigation is done using the **Angular Component Router**. You can check [this detailed guide on how to use the router](https://angular.io/guide/router). From here on we are going to assume that you are familiar with the basic concepts and concentrate on the specifics when doing navigation with Angular inside a NativeScript app.
 
 ## Configuration
 
@@ -54,7 +54,7 @@ We are also going to use the following route configuration file (`app.routes.ts`
 
 ## Router Links
 
-One thing you might have noticed in the code above is the `nsRouterLink` directive. It is similar to [`routerLink`](https://angular.io/docs/ts/latest/guide/router.html#!#-routerlink-binding), but works with NativeScript navigation. To use it, you need to import `NativeScriptRouterModule` in your NgModule.
+One thing you might have noticed in the code above is the `nsRouterLink` directive. It is similar to [`routerLink`](https://angular.io/api/router/RouterLink), but works with NativeScript navigation. To use it, you need to import `NativeScriptRouterModule` in your NgModule.
 
 ## Router Outlet
 
@@ -191,7 +191,7 @@ You might want to perform some cleanup actions (ex. unsubscribe from a service t
 
 ## Passing Parameter
 
-In Angular you can inject `ActivatedRoute` and read route parameters from it. Your component will be reused if you do a subsequent navigations to the same route while only changing the params. That's why `params` and `data` inside `ActivatedRoute` are observables. Using `ActivatedRoute` is covered in [angular route-parameters guide](https://angular.io/guide/router#route-parameters-in-the-activatedroute-service).
+In Angular you can inject `ActivatedRoute` and read route parameters from it. Your component will be reused if you do a subsequent navigations to the same route while only changing the params. That's why `params` and `data` inside `ActivatedRoute` are observables. Using `ActivatedRoute` is covered in [angular route-parameters guide](https://angular.io/api/router/ActivatedRoute).
 
 As explained in previous chapter, with `<page-router-outlet>` when navigating **back** to an existing page, your component will **not** be re-created. Angular router will still create an **new instance** `ActivatedRoute` and put all params in it, but you cannot get hold of it through injection, as your component is revived from the cache and not constructed anew.
 

--- a/docs/core-concepts/application-lifecycle.md
+++ b/docs/core-concepts/application-lifecycle.md
@@ -83,7 +83,7 @@ The component lifecycle is controlled by the Angular application. It creates, up
 * **ngDoCheck** - Detect and act upon changes that Angular can or won't detect on its own. Called every change detection run.
 * **ngOnDestroy** - Called just before Angular destroys the component.
 
-For a full list, see the official [Angular Lifecycle Hooks docs](https://angular.io/docs/ts/latest/guide/lifecycle-hooks.html).
+For a full list, see the official [Angular Lifecycle Hooks docs](https://angular.io/guide/lifecycle-hooks).
 
 ## Start application
 


### PR DESCRIPTION
#### Changes description
The links for angular docs were pointing to non existent URLS giving 404. Those are updated to correct URLs.

