### PR TITLE
docs: Add section for obtaining diagnostic logs

### DIFF
--- a/docs/get-support.md
+++ b/docs/get-support.md
@@ -9,9 +9,9 @@ publish: true
 # Get support
 
 * [Where to get help](#where-to-get-help)
-* [Known issues and limitations](#known-issues-and-limitations)
+* [How to obtain diagnostic reports](#how-to-obtain-diagnostic-reports)
 
-> **Installation Troubles?** Try [NativeScript Sidekick](https://www.nativescript.org/nativescript-sidekick) for a one-click setup experience for macOS, Windows, and Linux. Sidekick installs the NativeScript CLI and required dependencies for macOS and Windows - and offers starter kits, cloud-based builds for iOS and Android, and app store publishing.
+> **Installation Problems?** Try [NativeScript Sidekick](https://www.nativescript.org/nativescript-sidekick) for a one-click setup experience for macOS, Windows, and Linux. Sidekick installs the NativeScript CLI and required dependencies for macOS and Windows - and offers starter kits, cloud-based builds for iOS and Android, and app store publishing.
 
 ## Where to get help
 
@@ -27,3 +27,55 @@ If you’ve found an issue with the NativeScript framework itself, please report
 - [NativeScript iOS runtime](https://github.com/nativescript/ios-runtime)
 - [NativeScript Android runtime](https://github.com/nativescript/android-runtime)
 
+## How to obtain diagnostic reports
+When you find a bug or crash in NativeScript there are some additional diagnostic logs that can be very useful in tracking 
+down the reasons behind the faulty behavior. Depending on the component which could be responsible, there are different 
+settings that you can switch.  
+
+### CLI
+
+You can use the `--log trace` option of  `tns` to enable the most detailed diagnostic output. The accepted values of the 
+`log` option are `info`,  `debug` and `trace` (in increasing detailness)
+
+Example:
+`tns build ios --log trace`
+
+### Android Runtime
+
+If you suspect that the Android Runtime behaves incorrectly you can enable verbose output of its actions by calling the 
+`__enableVerboseLogging` function in your main `app.js` file. If your project is written in TypeScript, you'll have to 
+declare the function before calling it.
+
+Examples: 
+* JavaScript
+```JS
+__enableVerboseLogging();
+```
+* TypeScript
+```TS
+declare var __enableVerboseLogging : any;
+__enableVerboseLogging();
+```
+
+Afterwards you should launch your application and reproduce the issue:
+
+1. Clear the device's logcat by executing  `adb logcat  -c`
+2. Start the application and perform the steps required to reproduce the problem
+3. Save the logcat to a text file by executing  `adb logcat -d >logcat.txt`
+4. Open and analyze the generated `logcat.txt` file or attach it to your issue in GitHub 
+if you need assistence.
+
+### iOS Runtime
+
+In order to obtain device logs you can use the [Console application](https://support.apple.com/guide/console/welcome/mac)
+
+1. Launch `Console`
+2. Select your device from the left-hand side pane
+3. Press the `Clear` button from the toolbar
+4. Launch the application and reproduce the problem
+5. Click in the messages pane of `Console`
+6. Select all (`Edit | Select All` from the menu or `⌘+A`)
+7. Copy (`Edit | Copy` from the menu or `⌘+C`) 
+8. Open a new file in `TextEdit` or your text editor of choice
+9. Paste the copied text and save the file
+10. Analyze the file or attach it to your GitHub issue in order to get assistence


### PR DESCRIPTION
Add section in `Get Support` article describing how to
enable verbose logging from the {N} CLI and Runtimes.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] If there is an issue related with this PR, point it out here.

## What is the current state of the documentation article?
There's no info on how to get diagnostic information.

## What is the new state of the documentation article?
Added a new section on how to get diagnostic information.

Related to #1339 

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

