### PR TITLE
chore: update Android requirements

### DIFF
--- a/docs/start/ns-setup-linux.md
+++ b/docs/start/ns-setup-linux.md
@@ -19,10 +19,10 @@ This page contains a list of all system requirements needed to build and run Nat
 * The latest stable official release of Node.js (LTS) [8.x](https://nodejs.org/dist/latest-v8.x/) 
 * G++ compiler
 * JDK 8
-* Android SDK 22 or a later stable official release
+* Android SDK
 * Android Support Repository
 * (Optional) Google Repository
-* Android SDK Build-tools 27.0.3 or a later stable official release
+* Android SDK Build-tools 28.0.3 or a later stable official release
 
 You must also have the following two environment variables setup for Android development:
 
@@ -80,9 +80,9 @@ Complete the following steps to set up NativeScript on your Linux development ma
         <blockquote><b>NOTE</b>: This is the directory that contains the <code>tools</code> (just installed) and <code>platform-tools</code> (installed by scripts in the next step) directories.</blockquote>
      1. Logout from current user and login again so environment variables changes take place.
 
-1. Install all packages for the Android SDK Platform 26, Android SDK Build-Tools 27.0.3 or later, Android Support Repository, Google Repository and any other SDKs that you may need. You can alternatively use the following command, which will install all required packages. In order to install SDK's go to Android Studio -> Settings -> System Settings -> Android SDK -> Mark all the Android versions you would like to support within your project (The API Level column indicates the SDK Platform).
+1. Install all packages for the Android SDK Platform 28, Android SDK Build-Tools 28.0.3 or later, Android Support Repository, Google Repository and any other SDKs that you may need. You can alternatively use the following command, which will install all required packages. In order to install SDK's go to Android Studio -> Settings -> System Settings -> Android SDK -> Mark all the Android versions you would like to support within your project (The API Level column indicates the SDK Platform).
 
-    <pre class="add-copy-button"><code class="language-terminal">sudo $ANDROID_HOME/tools/bin/sdkmanager "tools" "emulator" "platform-tools" "platforms;android-26" "build-tools;27.0.3" "extras;android;m2repository" "extras;google;m2repository"
+    <pre class="add-copy-button"><code class="language-terminal">sudo $ANDROID_HOME/tools/bin/sdkmanager "tools" "emulator" "platform-tools" "platforms;android-28" "build-tools;28.0.3" "extras;android;m2repository" "extras;google;m2repository"
     </code></pre>
 
 1. Setup Android Emulators (AVD) by following the article [here]({%slug android-emulators%})

--- a/docs/start/ns-setup-os-x.md
+++ b/docs/start/ns-setup-os-x.md
@@ -28,7 +28,7 @@ This page contains a list of all system requirements needed to build and run Nat
     * Latest official release of Android SDK
     * Android Support Repository
     * (Optional) Google Repository
-    * Android SDK Build-tools 27.0.3 or later
+    * Android SDK Build-tools 28.0.3 or later
 
 You must also have the following two environment variables setup for Android development:
 
@@ -64,7 +64,7 @@ Complete the following steps to setup NativeScript on your macOS development mac
      Then restart the terminal or run `source ~/.bash_profile` command.
      
 1. Install the dependencies for iOS development.
-    1. Run the App Store and download and install Xcode 9 or later.
+    1. Run the App Store and download Xcode.
     1. Start Xcode and you will be prompted to install **Command Line Tools for Xcode**.
         1. To verify that the installation is correct please run
          ```
@@ -125,9 +125,9 @@ Complete the following steps to setup NativeScript on your macOS development mac
             <blockquote><b>NOTE</b>: This is the directory that contains the <code>tools</code> and <code>platform-tools</code> directories.</blockquote>
             <blockquote><b>NOTE</b>: In order to persist these variables after your terminal session is closed, they have to be persisted in your shell profile file (e.g. <code>~/.bash_profile</code> if you are using Bash, <code>~/.zprofile if you are using Zsh)</blockquote>            
 
-        1. In addition, install all packages for the Android SDK Platform 25, Android SDK Build-Tools 27.0.3 or later, Android Support Repository, Google Repository and any other SDKs that you may need. You can alternatively use the following command, which will install all required packages.
+        1. In addition, install all packages for the Android SDK Platform 28, Android SDK Build-Tools 28.0.3 or later, Android Support Repository, Google Repository and any other SDKs that you may need. You can alternatively use the following command, which will install all required packages.
 
-           <pre class="add-copy-button"><code class="language-terminal">$ANDROID_HOME/tools/bin/sdkmanager "tools" "emulator" "platform-tools" "platforms;android-25" "build-tools;27.0.3" "extras;android;m2repository" "extras;google;m2repository"
+           <pre class="add-copy-button"><code class="language-terminal">$ANDROID_HOME/tools/bin/sdkmanager "tools" "emulator" "platform-tools" "platforms;android-28" "build-tools;28.0.3" "extras;android;m2repository" "extras;google;m2repository"
            </code></pre>
            
            *If you are behind a corporate proxy, it might be necessary to pass additional arguments. You can check [sdkmanager documentation] (https://developer.android.com/studio/command-line/sdkmanager.html)*

--- a/docs/start/ns-setup-win.md
+++ b/docs/start/ns-setup-win.md
@@ -55,9 +55,9 @@ Complete the following steps to set up NativeScript on your Windows development 
 
     - Restart the command prompt.
 
-6. Install all packages for the Android SDK Platform 25, Android SDK Build-Tools 27.0.3 or later, Android Support Repository, Google Repository and any other SDKs that you may need. You can alternatively use the following command, which will install all required packages.
+6. Install all packages for the Android SDK Platform 28, Android SDK Build-Tools 28.0.3 or later, Android Support Repository, Google Repository and any other SDKs that you may need. You can alternatively use the following command, which will install all required packages.
 
-    <pre class="add-copy-button"><code class="language-terminal">"%ANDROID_HOME%\tools\bin\sdkmanager" "emulator" "platform-tools" "platforms;android-25" "build-tools;27.0.3" "extras;android;m2repository" "extras;google;m2repository"
+    <pre class="add-copy-button"><code class="language-terminal">"%ANDROID_HOME%\tools\bin\sdkmanager" "emulator" "platform-tools" "platforms;android-28" "build-tools;28.0.3" "extras;android;m2repository" "extras;google;m2repository"
     </code></pre>
 
 7. Install Android virtual devices (AVDs). There are multiple ways to do it so just choose one:

--- a/docs/start/quick-setup.md
+++ b/docs/start/quick-setup.md
@@ -82,10 +82,10 @@ After the installation the system setup should have:
 * The latest stable official release of Node.js (LTS) [8.x](https://nodejs.org/dist/latest-v8.x/) 
 * Google Chrome 
 * JDK 8
-* Android SDK 22 or a later stable official release
+* Android SDK
 * Android Support Repository
 * Google Repository
-* Android SDK Build-tools 27.0.3 or a later stable official release
+* Android SDK Build-tools 28.0.3 or a later stable official release
 * Android Studio
 * Set up Android virtual devices to expand your testing options 
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] If there is an issue related with this PR, point it out here.

## What is the current state of the documentation article?
Now docs require Android SDK 25/26.

## What is the new state of the documentation article?
{N} 5.0 require Android SDK 28.