### PR TITLE
fix: Remove the NativeScript Documentation link from Get Started navigation

### DIFF
--- a/docs/start/landing.md
+++ b/docs/start/landing.md
@@ -2,4 +2,5 @@
 title: NativeScript Documentation
 description: NativeScript Documentation - an open-source framework for the cross-platform development of truly native apps.
 layout: landing
+publish: false
 ---


### PR DESCRIPTION
Unless I am missing something, adding the `publish: false` variable to the landing page (landing.md) removes the `NativeScript Documentation` link from the navigation without causing issues.

