### PR TITLE
Set 'stack' as the root view not 'label' under TS snippet

### DIFF
--- a/docs/core-concepts/navigation.md
+++ b/docs/core-concepts/navigation.md
@@ -89,7 +89,7 @@ export function createPage(): Page {
 
     const page = new Page();
     // Each page can have a single root view set via the content property
-    page.content = label;
+    page.content = stack;
     return page;
 }
 ```


### PR DESCRIPTION
docs(NAVIGATION): change "label" to "stack" as root view for page

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] If there is an issue related with this PR, point it out here.

## What is the current state of the documentation article?
In the "Define Page" section here: [Navigation/Define Page](https://docs.nativescript.org/core-concepts/navigation#define-page), under "Create a page in code", in the TypeScript snippet, the 3rd line from the bottom that sets the page.content property is setting it to the "label" variable.

## What is the new state of the documentation article?
Change the root view of the page in the TypeScript snippet to point to the "stack" variable.


