### PR TITLE
Added acclaration about transitions in android

### DIFF
--- a/docs/core-concepts/navigation.md
+++ b/docs/core-concepts/navigation.md
@@ -496,7 +496,7 @@ frame.navigate(navigationEntry);
 
 ### Navigation transitions
 
-By default, all navigation will be animated and will use the default transition for the respective platform (UINavigationController transitions for iOS and Fragment transitions for Android). To change the transition type, set the `navigationTransition` property of the [`NavigationEntry`](http://docs.nativescript.org/api-reference/interfaces/_ui_frame_.navigationentry.html) to an object conforming to the [`NavigationTransition`](http://docs.nativescript.org/api-reference/interfaces/_ui_frame_.navigationtransition.html) interface.
+By default, all navigation will be animated and will use the default transition for the respective platform (UINavigationController transitions for iOS and Fragment transitions for Android). To change the transition type, set the `navigationTransition` property of the [`NavigationEntry`](http://docs.nativescript.org/api-reference/interfaces/_ui_frame_.navigationentry.html) to an object conforming to the [`NavigationTransition`](http://docs.nativescript.org/api-reference/interfaces/_ui_frame_.navigationtransition.html) interface. (For android this requires at least API 25 [Android 5.0])
 ``` JavaScript
 const getFrameById = require("tns-core-modules/ui/frame").getFrameById;
 


### PR DESCRIPTION
Updated the Navigation Transition to show the minium API required for android
## What is the new state of the documentation article?
Added line "(For android this requires at least API 25 [Android 5.0])" in the Navigation Transition part.

