### PR TITLE
docs(core-concepts/navigation): copy navigation pathing tip from ui/basics

### DIFF
--- a/docs/core-concepts/navigation.md
+++ b/docs/core-concepts/navigation.md
@@ -253,6 +253,8 @@ frame.navigate("second/second-page");
 <Frame id="firstFrame" defaultPage="home/home-page"/>
 ```
 
+> Paths are relative to the application root. In the example above, NativeScript looks for a `my-page.xml` file in the app directory of your project (e.g. `app/my-page.xml`).
+
 There are several ways to perform a navigation; which one you use depends on the needs of your app.
 
 ### Navigate by page name


### PR DESCRIPTION
docs(core-concepts/navigation): copy navigation pathing tip from ui/basics

Copying the pathing tip from 'The Basics' document into the 'Architecture and Navigation' document to keep people from missing that important tip (as I did)

there is no related issue for this docs change


<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] If there is an issue related with this PR, point it out here.

## What is the current state of the documentation article?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
the 'Basic Navigation' section of the 'Architecture and Navigation' document DOES NOT have the pathing tip from the 'Navigate To A Page' section of the 'The Basics' document 

## What is the new state of the documentation article?
<!-- Describe the changes. -->
The pathing tip from the 'Navigate To A Page' section of the 'The Basics' document HAS BEEN COPIED into the 'Basic Navigation' section of the 'Architecture and Navigation' document

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

