### PR TITLE
chore: add produce aab section in aab article

### DIFF
--- a/docs/tooling/publishing/android-app-bundle.md
+++ b/docs/tooling/publishing/android-app-bundle.md
@@ -8,6 +8,12 @@ slug: android-app-bundle
 # Android App Bundle
 An Android App Bundle is a new publishing format that contains all the compiled code and resources of your app, but leaves the actual APK generation and signing to Google Play. The store then uses the app bundle to generate and serve optimized APKs based on the device configuration of the specific user. In general, the benefit of using Android App Bundles is that you no longer have to build, sign, and manage multiple APKs to support different devices, and users get smaller, more optimized downloads. For more information about the Android App Bundle, see the About Android App Bundles article in the official [Android Developer documentation](https://developer.android.com/guide/app-bundle/).
 
+## Produce Android App Bundle
+You can perform a full build and produce a signed AAB using the NativeScript CLI:
+```
+tns build android --release --key-store-path <path-to-your-keystore> --key-store-password <your-key-store-password> --key-store-alias <your-alias-name> --key-store-alias-password <your-alias-password> --aab --copy-to <aab-location>.aab
+```
+
 ## Available configurations
 By default, the 'arm64-v8a' CPU architecture is excluded from the build of NativeScript application. The following configuration will enable it, but there is a chance that on older devices with this architecture this might affect the startup times.
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] If there is an issue related with this PR, point it out here.

## What is the current state of the documentation article?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
In the Android App Bundle article there is no information on how to produce an `.aab` file.

## What is the new state of the documentation article?
<!-- Describe the changes. -->
In the Android App Bundle article there is a section on how to produce an `.aab` file.

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

