### PR TITLE
chore: fix reference to Android App Bundle article in publishing

### DIFF
--- a/docs/tooling/publishing/publishing-android-apps.md
+++ b/docs/tooling/publishing/publishing-android-apps.md
@@ -154,7 +154,7 @@ You can then use the produced `<apk-location>.apk` for upload to *Google Play*.
 
 ### APKs with ABI splits
 
-If you want to reduce the apk sizes you can check how to achieve this in [Android ABI Split article](http://docs.nativescript.org/publishing/android-abi-split.html).
+If you want to reduce the apk sizes you can check how to achieve this in [Android ABI Split article]({% slug android-abi-split %}).
 
 <h4 id="submit-with-the-google-play-developer-console">Submit with the Google Play Developer Console</h4>
 
@@ -170,7 +170,7 @@ You can read more about these stages at ["Set up alpha/beta tests"](https://supp
 Once you upload your APK, it will go through a review. When approved, you can move it to production to make it available on *Google Play*.
 
 ### Android App Bundle
-If you want to reduce the size of the application download from Google Play Store you can check how to achieve this in [Android App Bundle article](http://docs.nativescript.org/publishing/android-app-bundle.html).
+If you want to reduce the size of the application download from Google Play Store you can check how to achieve this in [Android App Bundle article]({% slug android-app-bundle %}).
 
 You can perform a full build and produce a signed AAB using the NativeScript CLI:
 ```


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] If there is an issue related with this PR, point it out here.

## What is the current state of the documentation article?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Reference to Android App Bundle in publishing article does not work.

## What is the new state of the documentation article?
<!-- Describe the changes. -->
Reference to Android App Bundle in publishing article does work.

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

