### PR TITLE
docs: [Known issue] SIMD Vectors are unsupported for 32-bit archs

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -83,3 +83,12 @@ The package manager service found that the device didn't have enough storage spa
 **Solution:**
 
 Solution provided by [KristiyanFxy](https://github.com/KristiyanFxy) a member of the NativeScript community. Link to original solution [here](https://github.com/NativeScript/nativescript-cli/issues/2486#issuecomment-355299977).
+
+### iOS Runtime limitations and known issues
+
+**Problem:** Calling native functions having SIMD vector return type and/or arguments on `i386` and `armv7` architectures crashes or returns garbage. See https://github.com/NativeScript/ios-runtime/issues/997 for any updates regarding the problem.
+
+**Solution:** The 3rd party library that iOS Runtime uses to make native calls ([libffi/libffi](https://github.com/libffi/libffi/)) does
+not support SIMD vectors for these 2 architectures. If your app needs to support 32-bit iOS devices and you want to consume such functions you
+must do so from the native part of a plugin in your app. Visit [Building Plugins](./building-plugins.md) for more information on how to create one.
+


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] Related to https://github.com/NativeScript/ios-runtime/issues/997

