### PR TITLE
Update ns-setup-linux.md

### DIFF
--- a/docs/start/ns-setup-linux.md
+++ b/docs/start/ns-setup-linux.md
@@ -63,21 +63,20 @@ Complete the following steps to set up NativeScript on your Linux development ma
         <pre class="add-copy-button"><code class="language-terminal">sudo update-alternatives --config java
         </code></pre>
 
-    3. Set the JAVA_HOME system environment variable.
+    3. Set the JAVA_HOME system environment variable. Open `~/.bashrc` and add the following:
 
-        <pre class="add-copy-button"><code class="language-terminal">export JAVA_HOME=$(update-alternatives --query javac | sed -n -e 's/Best: *\(.*\)\/bin\/javac/\1/p')
-        </code></pre>
+        <pre class="add-copy-button"><code class="language-terminal">export JAVA_HOME=$(update-alternatives --query javac | sed -n -e 's/Best: *\(.*\)\/bin\/javac/\1/p')</code></pre>
 
 5. Install the [Android SDK](http://developer.android.com/sdk/index.html).
     1. Go to [Android Studio and SDK Downloads](https://developer.android.com/sdk/index.html#Other) and in the **SDK Tools Only** section download the package for Linux at the bottom of the page.
-    2. After the download completes, unpack the downloaded archive into a folder, such as `/android/sdk`
-       * The archive you just extracted was the `tools` folder, so in this case it would be at: `/android/sdk/tools`
-    3. Set the ANDROID_HOME system environment variable.
-        <pre><code class="language-terminal">sudo -H gedit /etc/environment
-        </code></pre>
+    2. After the download completes, unpack the downloaded archive into a folder, such as `/usr/local/android/sdk`
+       * The archive you just extracted was the `tools` folder, so in this case it would be at: `/usr/local/android/sdk/tools`
+    3. Set the ANDROID_HOME environment variable. Open `~/.bashrc` and add the following:
+        <pre><code class="language-terminal">export ANDROID_HOME="/usr/lib/android-sdk/"
+       export PATH="${PATH}:${ANDROID_HOME}tools/:${ANDROID_HOME}platform-tools/"</code></pre>
     4. In a text file which was opened, paste in the path to your variable (at the new line).
     
-    For example: `ANDROID_HOME=/android/sdk`
+    For example: `ANDROID_HOME=/usr/local/android/sdk`
         <blockquote><b>NOTE</b>: This is the directory that contains the <code>tools</code> (just installed) and <code>platform-tools</code> (installed by scripts in the next step) directories.</blockquote>
      1. Logout from current user and login again so environment variables changes take place.
 


### PR DESCRIPTION
As discussed in [this SO question](https://stackoverflow.com/questions/7535569/what-is-an-appropriate-directory-in-which-to-install-android-sdk). `/usr/local` should be the right place for the android sdk.

Also putting it is the `/` seems to be a bad idea. The android sdk is too large to be put in `/` in my opinion.

Regarding the environmental variable, I user `~/.bashrc` in favor of `/etc/environment`. For some reason using `/etc/environment` won't cut it. 

A [reference](https://stackoverflow.com/questions/26256279/how-to-set-android-home-path-in-ubuntu) for using `~/.bashrc`

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] If there is an issue related with this PR, point it out here.

## What is the current state of the documentation article?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new state of the documentation article?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

