### PR TITLE
Update ns-setup-linux.md

### DIFF
--- a/docs/start/ns-setup-linux.md
+++ b/docs/start/ns-setup-linux.md
@@ -69,10 +69,10 @@ Complete the following steps to set up NativeScript on your Linux development ma
 
 5. Install the [Android SDK](http://developer.android.com/sdk/index.html).
     1. Go to [Android Studio and SDK Downloads](https://developer.android.com/sdk/index.html#Other) and in the **SDK Tools Only** section download the package for Linux at the bottom of the page.
-    2. After the download completes, unpack the downloaded archive into a folder, such as `/usr/local/android/sdk`
+    2. After the download completes, unpack the downloaded archive into a folder, such as `/usr/lib/android/sdk`
        * The archive you just extracted was the `tools` folder, so in this case it would be at: `/usr/local/android/sdk/tools`
     3. Set the ANDROID_HOME environment variable. Open `~/.bashrc` and add the following:
-        <pre><code class="language-terminal">export ANDROID_HOME="/usr/lib/android-sdk/"
+        <pre><code class="language-terminal">export ANDROID_HOME="/usr/lib/android/sdk"
        export PATH="${PATH}:${ANDROID_HOME}tools/:${ANDROID_HOME}platform-tools/"</code></pre>
     4. In a text file which was opened, paste in the path to your variable (at the new line).
     


### PR DESCRIPTION
When I tryed to follow step 6 to found usr/lib/android-sdk I have got an error `Not Found`. Problem was in next. We set as ANDROID_HOME variable `usr/lib/android-sdk/` but at step 5 we extract an archive to `usr/local/android/sdk`. As you can see it is different paths.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] If there is an issue related with this PR, point it out here.

## What is the current state of the documentation article?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new state of the documentation article?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

