### PR TITLE
Add iOS custom flags article  

### DIFF
--- a/docs/core-concepts/android-runtime/advanced-topics/custom-flags.md
+++ b/docs/core-concepts/android-runtime/advanced-topics/custom-flags.md
@@ -3,7 +3,7 @@ title: "Custom Flags"
 description: "Configure various V8 engine flags in order to improve the performance of your app, or to obtain more comprehensive information during debugging"
 position: 5
 previous_url: /core-concepts/android-runtime/advanced-topics/v8-flags
-slug: custom-flags
+slug: android-custom-flags
 ---
 
 # Custom Flags
@@ -79,5 +79,7 @@ By default, if an exception is thrown when executing JavaScript code which is ca
     ...
 }
 ```
+
+The discarded exceptions can be processed in the app by subscribing to `application.discardedErrorEvent` or by assigning a one-argument function to `global.__onDiscardedError`.
 
 > **NOTE:** The `discardUncaughtJsExceptions` works on iOS as well. This is why in the example above the flag is not assigned to the `android` object.

--- a/docs/core-concepts/ios-runtime/custom-flags.md
+++ b/docs/core-concepts/ios-runtime/custom-flags.md
@@ -1,0 +1,62 @@
+---
+title: "Custom Flags"
+description: "Configure various iOS Runtime flags in order to alter behavior, improve performance, or obtain more comprehensive debug information of your app"
+position: 5
+slug: ios-custom-flags
+---
+
+# Custom JavaScriptCore Flags
+
+The JavaScriptCore engine has a set of controlling flags that may be useful for fine-grained application tuning. You can set these flags in the [secondary package.json configuration file]({% slug structure %}#apppackagejson).
+
+Example:
+```JSON
+{
+    ...
+    "ios": {
+        "jscFlags": "--dumpOptions=3 --validateOptions=1"
+    }
+    ...
+}
+```
+
+Another way of enabling JSC options without persisting them in your project during a debug session is to set `JSC_` prefixed environment variables for each of the options that you want to set. For example:
+
+```
+JSC_dumpOptions=3
+JSC_validateOptions=1
+```
+
+For detailed information on how to pass environment variables during a debug run from Xcode see the ***Debugging Options in the Scheme Editor*** section of the [Debugging Tools article from the Xcode documentation](https://developer.apple.com/library/archive/documentation/DeveloperTools/Conceptual/debugging_with_xcode/chapters/debugging_tools.html)
+
+## Log garbage collection statistics
+
+`gcLogLevel` - debugging option to log GC activity (0 = None, 1 = Basic, 2 = Verbose)
+
+## Log module loading internals
+
+* `dumpModuleRecord` - dump the ModuleRecord after a new module is `import`-ed or `require`-ed
+* `dumpModuleLoadingState` - log the different phases of module loading (resolving, fetching, parsing, evaluating)
+* `exposeInternalModuleLoader` - expose the internal module loader object to the global space for debugging as `global.Loader`
+
+## JSC Options diagnostics
+* `validateOptions` - crash if mis-typed JSC options were passed to the VM
+* `dumpOptions` - dump JSC options (0 = None, 1 = Overridden only, 2 = All, 3 = Verbose)
+
+> **NOTE:** This section contains only a small portion of the available flags. For a complete list of all JSC flags, see [JSC_OPTIONS macro definition in Options.h in GitHub](https://github.com/NativeScript/webkit/blob/ios/Source/JavaScriptCore/runtime/Options.h#L115). Have in mind that flags marked with `Restricted` cannot be configured in NativeScript because the supplied **JavaScriptCore** is built in **Release** configuration.
+
+# Discarding JavaScript exceptions when called from native
+
+By default, the application will crash if an exception is thrown when executing JavaScript code which is called from some native API. If you want to suppress the crash you can enable the `discardUncaughtJsExceptions` flag:
+
+```JSON
+{
+    ...
+    "discardUncaughtJsExceptions": true
+    ...
+}
+```
+
+The discarded exceptions can be processed in the app by subscribing to `application.discardedErrorEvent` or by assigning a one-argument function to `global.__onDiscardedError`.
+
+> **NOTE:** The `discardUncaughtJsExceptions` works on Android as well. This is why in the example above the flag is not assigned to the `ios` object.

--- a/docs/core-concepts/ios-runtime/custom-flags.md
+++ b/docs/core-concepts/ios-runtime/custom-flags.md
@@ -31,7 +31,7 @@ For detailed information on how to pass environment variables during a debug run
 
 ## Log garbage collection statistics
 
-`gcLogLevel` - debugging option to log GC activity (0 = None, 1 = Basic, 2 = Verbose)
+`logGC` - debugging option to log GC activity (0 = None, 1 = Basic, 2 = Verbose)
 
 ## Log module loading internals
 

--- a/docs/core-concepts/project-structure.md
+++ b/docs/core-concepts/project-structure.md
@@ -9,7 +9,7 @@ previous_url: /structure
 # Project Structure
 
 {% nativescript %}
-The default structure of a blank NativeScript project consists of a root folder that contains the `app`, `platforms` and `node_modules` directories, and a `package.json` configuration file. 
+The default structure of a blank NativeScript project consists of a root folder that contains the `app`, `platforms` and `node_modules` directories, and a `package.json` configuration file.
 
 ```
 myApplication/
@@ -23,7 +23,7 @@ myApplication/
 {% endnativescript %}
 
 {% angular %}
-The default structure of a blank NativeScript + Angular project consists of a root folder that contains the `src`, `platforms`, `node_modules` and `hooks` directories, and several configuration files amongst which the most important is the `package.json`. 
+The default structure of a blank NativeScript + Angular project consists of a root folder that contains the `src`, `platforms`, `node_modules` and `hooks` directories, and several configuration files amongst which the most important is the `package.json`.
 
 ```
 myApplication/
@@ -38,7 +38,7 @@ myApplication/
 ├── tsconfig.json
 └── ...
 ```
-{% endangular%} 
+{% endangular%}
 
 There are several other directories and configuration files that can be present in your project based on the initial template, the programming language (JavaScript or TypeScript) or the plugins that you are using in your application. This article covers the files and folders that are always present in a NativeScript project, as well as some of the more common ones that you may encounter while developing your app.
 
@@ -54,16 +54,19 @@ You can develop shared functionality or design in common files. To indicate that
 
 ### {% nativescript %}app{% endnativescript %}{% angular %}src{% endangular %}/package.json
 
-This is a secondary `package.json` file in which you can specify the entry point file of the application and also several [Android-specific custom flags]({% slug custom-flags %}). Below is an example of a basic secondary `package.json` file.
+This is a secondary `package.json` file in which you can specify the entry point file of the application and also several [Android-specific]({% slug android-custom-flags %}) and [iOS-specific]({% slug ios-custom-flags %}) custom flags. Below is an example of a basic secondary `package.json` file.
 
 {% nativescript %}
 ```JSON
 {
     "main": "app.js",
+    "discardUncaughtJsExceptions": true,
     "android": {
         "v8Flags": "--expose_gc",
-        "forceLog": true,
-        "discardUncaughtJsExceptions": true
+        "forceLog": true
+    },
+    "ios": {
+        "jscFlags": "--dumpOptions=2 --validateOptions=1"
     }
 }
 ```
@@ -72,10 +75,13 @@ This is a secondary `package.json` file in which you can specify the entry point
 ```JSON
 {
     "main": "main.js",
+    "discardUncaughtJsExceptions": true,
     "android": {
         "v8Flags": "--expose_gc",
-        "forceLog": true,
-        "discardUncaughtJsExceptions": true
+        "forceLog": true
+    },
+    "ios": {
+        "jscFlags": "--dumpOptions=2 --validateOptions=1"
     }
 }
 ```


### PR DESCRIPTION
Document the following:

* `jscFlags`
* `discardUncaughtJsExceptions`
* `application.discardedErrorEvent` and `global.__onDiscardedError`
* automatic GC triggering parameters 

related to https://github.com/NativeScript/NativeScript/issues/6776, https://github.com/NativeScript/ios-runtime/issues/1004 and https://github.com/NativeScript/ios-runtime/issues/1035


## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] If there is an issue related with this PR, point it out here.

## What is the new state of the documentation article?
Added article about iOS runtime flags that {N} developers can configure in their apps
