### PR TITLE
Fixing a broken image link to the {N}-Vue logo

### DIFF
--- a/vuejs-docs/nativescript-vuejs.md
+++ b/vuejs-docs/nativescript-vuejs.md
@@ -9,7 +9,7 @@ publish: true
 
 <a href="https://vuejs.org" target="_blank">Vue.js</a> is a lightweight, ‘progressive framework’ for building user interfaces. NativeScript integrates with Vue.js to offer a standard way for building cross-platform native mobile apps. If you have used Vue.js before you’ll feel right at home with NativeScript-Vue.
 
-![](/img/vue/nativescript-vue.png)
+![](https://docs.nativescript.org/img/vue/nativescript-vue.png)
 
 ## Get Started
 


### PR DESCRIPTION
This is a trivial image path fix. I believe the issue here is because of path rewrites, so there might be a more elegant way of solving this but this gets the job done for now.