### PR TITLE
Update basics.md Docs [Typo]

### DIFF
--- a/docs/ui/basics.md
+++ b/docs/ui/basics.md
@@ -893,6 +893,6 @@ Since the release of NativeScript 1.3, you can declare your UI using the lowerca
   <scroll-view>
     <stack-layout>
       <label ctext="Label" />
-      <utton text="Button" tap="tap" />
+      <button text="Button" tap="tap" />
       ...
 ```


### PR DESCRIPTION
## What is the current state of the documentation article?
There's a typo in the code block under `Lowercase-dashed component declaration`.

## What is the new state of the documentation article?
Fixes the typo.


