### PR TITLE
docs: improved iOS font recognition description

### DIFF
--- a/docs/ui/icon-fonts.md
+++ b/docs/ui/icon-fonts.md
@@ -40,7 +40,19 @@ In the above example, the `fa-brands-400.ttf` (as downloaded from the FontAwesom
 |**fa-solid-900** | Font Awesome 5 Free
 |**fa-regular-400** | Font Awesome 5 Free
 
-Notice that in the above example the **file** names are different, but the registered **font** name is the same (use the **Font Book** application on Mac or the **Control Panel Fonts** section on Windows to see the actual font name). While this is no issue on Android, it renders the second font unusable on iOS. To handle similar cases, manually change the font name (e.g., via a third-party tool like [FontForge](http://fontforge.github.io/).
+Notice that in the above example the **file** names are different, but the registered **font** name is the same (use the **Font Book** application on Mac or the **Control Panel Fonts** section on Windows to see the actual font name). While this is no issue on Android, it renders the second font unusable on iOS. To handle similar cases additional CSS font properties, such as for example `font-weight`, must be added.
+
+```CSS
+.far {
+    font-family: "Font Awesome 5 Free", "fa-regular-400";
+    font-weight: 400;
+}
+
+.fas {
+    font-family: "Font Awesome 5 Free", "fa-solid-900";
+    font-weight: 900;
+}
+```
 
 {% nativescript %}
 ## Icon Fonts via XML


### PR DESCRIPTION
## What is the current state of the documentation article?
Currently, the documentation says that because iOS font recognition use **font name** to load the font, then if fonts have the same **font name** but different **file name**, then iOS can't distinguish them, and **font name** must be changed to be different.

## What is the new state of the documentation article?
But actually, if additional CSS font parameter, which concrete recognition, added, then the same **font name** is not a problem.
Also, CSS code snipped for Font Awesome (fontawesome-free-5.7.2-web) with this technic added.

Example Playground - https://play.nativescript.org/?template=play-tsc&id=PlfxSn&v=2