### PR TITLE
Add a Playground link to help users find our new tutorial there

### DIFF
--- a/vuejs-docs/nativescript-vuejs.md
+++ b/vuejs-docs/nativescript-vuejs.md
@@ -15,9 +15,13 @@ publish: true
 
 ## Get Started
 
-The NativeScript-Vue documentation lives at [nativescript-vue.org](https://nativescript-vue.org/en/docs/introduction/).
+The easiest place to learn NativeScript-Vue is with the interactive tutorials in [NativeScript Playground](https://play.nativescript.org/), our browser-based NativeScript development environment.
 
-<a href="https://nativescript-vue.org/en/docs/introduction/" class="ns-button -action" id="ng-start-button">Get Started with NativeScript-Vue</a>
+<a href="https://play.nativescript.org" class="ns-button -action" id="ng-start-button">Get Started with NativeScript-Vue</a>
+
+When you need to take the next step, head to the [NativeScript-Vue documentation hub](https://nativescript-vue.org/en/docs/introduction/) for information on setting up a local environment, NativeScript-Vue UI components, and more.
+
+<a href="https://nativescript-vue.org/en/docs/introduction/" class="ns-button -action" id="ng-start-button">Visit the NativeScript-Vue documentation</a>
 
 ## Join the NativeScript-Vue Community
 


### PR DESCRIPTION
Here’s a quick visual so you can see what this looks like. Basically this is to help people find our new Vue.js tutorial on Playground.

![screen shot 2019-02-15 at 2 31 57 pm](https://user-images.githubusercontent.com/544280/52880060-ef9fe180-312e-11e9-8c19-5517c66f4b3f.png)
