### PR TITLE
fix: clarify that the API Reference is only about the Core Modules

### DIFF
--- a/build/_layouts/landing.html
+++ b/build/_layouts/landing.html
@@ -173,7 +173,7 @@
                         <hr/>
                         <h3 class="start-links__title">API Reference</h3>
                         <ul>
-                            <li><a href="/api-reference">Documentation</a></li>
+                            <li><a href="/api-reference">Core Modules</a></li>
                         </ul>
                         <ul>
                             <li><a href="/ns-ui-api-reference">NativeScript UI</a></li>


### PR DESCRIPTION
The current API Reference contains information only about APIs exposed by the Core Modules. I suggest to make it clear and point out this in the navigation.