### PR TITLE
docs(Getting Started-NativeScript Advanced Setup — Linux) - Environment variable setup needed minor correction

### DIFF
--- a/docs/start/ns-setup-linux.md
+++ b/docs/start/ns-setup-linux.md
@@ -70,7 +70,7 @@ Complete the following steps to set up NativeScript on your Linux development ma
     2. After the download completes, unpack the downloaded archive into a folder, such as `/usr/lib/android/sdk`
        * The archive you just extracted was the `tools` folder, so in this case it would be at: `/usr/local/android/sdk/tools`
     3. Set the ANDROID_HOME environment variable. Open `~/.bashrc` and add the following:
-        <pre><code class="language-terminal">export ANDROID_HOME="/usr/lib/android/sdk"
+        <pre><code class="language-terminal">export ANDROID_HOME="/usr/lib/android/sdk/"
        export PATH="${PATH}:${ANDROID_HOME}tools/:${ANDROID_HOME}platform-tools/"</code></pre>
     4. In a text file which was opened, paste in the path to your variable (at the new line).
     


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x ] If there is an issue related with this PR, point it out here.

## What is the current state of the documentation article?
"export ANDROID_HOME="/usr/lib/android/sdk" should have a trailing slash or else the path variable will become: "/usr/lib/android/sdktools", which would be wrong.  It should be "/usr/lib/android/sdk/tools"

## What is the new state of the documentation article?
Just added a post slash to the ANDROID_HOME env variable. This should do the job.

