### PR TITLE
docs(ui/styling): add extension to cssFileName

### DIFF
--- a/docs/ui/styling.md
+++ b/docs/ui/styling.md
@@ -166,10 +166,10 @@ page.addCss("button {background-color: blue}");
 This snippet adds new CSS styles to the current set. However, this method reads them from a file. It is useful for organizing styles in files and reusing them across multiple pages.
 
 ``` JavaScript
-page.addCssFile(cssFileName);
+page.addCssFile(cssFileName.css);
 ```
 ``` TypeScript
-page.addCssFile(cssFileName);
+page.addCssFile(cssFileName.css);
 ```
 
 > The path to the CSS file is relative to the application root folder.


### PR DESCRIPTION
There's an inconsistency in NativeScript when passing file path strings to methods. Sometimes you include the file extension, and others you don't. This change clarifies that here, the extension `.css` must be included in the file path string.

