### PR TITLE
fix(build): Update docker base image to ruby:2.6.1-alpine3.9

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3.5-alpine3.4
+FROM ruby:2.6.1-alpine3.9
 
 RUN apk add --update \
   bash \
@@ -10,6 +10,7 @@ RUN apk add --update \
   rsync \
   nginx \
   nodejs \
+  npm \
   && npm config set unsafe-perm true \
   && rm -rf /var/cache/apk/* \
   && npm config set cache /var --global \

--- a/build/Gemfile
+++ b/build/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'uglifier'
+gem 'json', '1.8.6'
 gem 'jekyll', '3.0.1'
 gem 'jekyll-sitemap'
 gem 'jekyll-assets'

--- a/build/Gemfile.lock
+++ b/build/Gemfile.lock
@@ -42,7 +42,7 @@ GEM
     jekyll-unsanitize (0.4)
     jekyll-watch (1.4.0)
       listen (~> 3.0, < 3.1)
-    json (1.8.3)
+    json (1.8.6)
     kramdown (1.11.1)
     liquid (3.0.6)
     listen (3.0.8)
@@ -90,6 +90,7 @@ DEPENDENCIES
   jekyll-assets
   jekyll-sitemap
   jekyll-unsanitize (= 0.4)
+  json (= 1.8.6)
   uglifier
 
 BUNDLED WITH

--- a/build/build-docs.sh
+++ b/build/build-docs.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 
 SCRIPT_PATH="$( cd "$(dirname "$0")" ; pwd -P )"
 ROOT=$SCRIPT_PATH"/bin"
@@ -53,7 +53,7 @@ cp -r $SCRIPT_PATH"/_config_vuejs.yml" \
 	  $SCRIPT_PATH"/_includes" \
 	  $SCRIPT_PATH"/fonts" \
 	  $VUEJS_ROOT
-	  
+
 rm $VUEJS_ROOT"/_plugins/redirect_generator.rb" \
    $VUEJS_ROOT"/_plugins/snippet.rb" \
    $VUEJS_ROOT"/_plugins/ns_cookbook.rb"
@@ -83,8 +83,8 @@ if [ -f $NS_UI_LV"/README.md" ]; then
 		cd "../demo-angular"
 		npm install markdown-snippet-injector
 		npm run inject
-		
-		
+
+
 	done
 
 	cd $NS_UI_API_REF

--- a/build/docs-watcher/start.sh
+++ b/build/docs-watcher/start.sh
@@ -26,7 +26,7 @@ trap 'sigint_handler' SIGINT
 mkdir -p /www
 
 if [ ! -d /root/./nativescript-ui-listview ]; then
-	mkdir /root/./nativescript-ui-listview 
+	mkdir /root/./nativescript-ui-listview
 
 fi
 if [ ! -d /root/./nativescript-ui-autocomplete ]; then
@@ -35,10 +35,10 @@ if [ ! -d /root/./nativescript-ui-autocomplete ]; then
 fi
 if [ ! -d /root/./nativescript-ui-dataform ]; then
 	mkdir /root/./nativescript-ui-dataform
-	
+
 fi
 if [ ! -d /root/./nativescript-ui-chart ]; then
-	mkdir /root/./nativescript-ui-chart 
+	mkdir /root/./nativescript-ui-chart
 
 fi
 if [ ! -d /root/./nativescript-ui-calendar ]; then
@@ -47,18 +47,18 @@ if [ ! -d /root/./nativescript-ui-calendar ]; then
 fi
 if [ ! -d /root/./nativescript-ui-gauge ]; then
 	mkdir /root/./nativescript-ui-gauge
-	
+
 fi
 if [ ! -d /root/./nativescript-ui-sidedrawer ]; then
 	mkdir /root/./nativescript-ui-sidedrawer
-	
+
 fi
 if [ ! -d /root/./docs/ns_ui_api-reference/ns-ui-api-reference ]; then
-	mkdir /root/./docs/ns_ui_api-reference/ns-ui-api-reference 
+	mkdir /root/./docs/ns_ui_api-reference/ns-ui-api-reference
 
 fi
 echo "Start copying mounted folders..."
-rsync --relative -az --exclude node_modules/ \
+rsync --relative -az --exclude node_modules/ --exclude .git \
 	/root/./docs \
 	/root/./NativeScript \
 	/root/./nativescript-angular \


### PR DESCRIPTION
NativeScript CLI's Gruntfile now uses async functions which are unsupported 
on NodeJS 4.x which comes with `ruby:2.3.5-alpine3.4`.