### PR TITLE
docs(ui/styling): clarify addCssFile requirements

### DIFF
--- a/docs/ui/styling.md
+++ b/docs/ui/styling.md
@@ -172,7 +172,7 @@ page.addCssFile(cssFileName);
 page.addCssFile(cssFileName);
 ```
 
-> The path to the CSS file is relative to the application root folder.
+> The path to the CSS file is relative to the application root folder, and must include the `.css` file extension.
 
 ### Inline CSS
 


### PR DESCRIPTION
Sometimes in NativeScript we include file extensions in paths and others not. This change will help clarify that this path does require the `.css` extension.

