### PR TITLE
docs(README) Added missing type definitions from example.

### DIFF
--- a/docs/plugins/ui-plugin-custom.md
+++ b/docs/plugins/ui-plugin-custom.md
@@ -35,6 +35,29 @@ You can implement this by creating four files:
 - **my-button.ios.ts** - holds the iOS-specific logic for creation of the native view (UIButton)
 - **my-button.android.ts** - holds the Android-specific logic for creation of the native view (android.widget.Button)
 
+This file holds type definitions for the common logic that will be imported in the app that is using the plugin.
+_my-button.d.ts_
+```TypeScript
+import { View, Style, Property, CssProperty, EventData } from "tns-core-modules/ui/core/view";
+
+export class MyButton extends View {
+    // static field used from component-builder module to find events on controls.
+    static tapEvent: string; 
+
+    // Defines the text property.
+    text: string;
+
+    // Overload 'on' method so that it provides intellisense for 'tap' event.
+    on(event: "tap", callback: (args: EventData) => void, thisArg?: any);
+
+    // Needed when 'on' method is overriden.
+    on(eventNames: string, callback: (data: EventData) => void, thisArg?: any);
+}
+
+export const textProperty: Property<MyButton, string>;
+export const myOpacityProperty: CssProperty<Style, number>;
+```
+
 In the following way you create the common logic:
 _my-button.common.ts_
 ```TypeScript


### PR DESCRIPTION
While following this guide I had to go to the full source code to see the type definitions file referenced at the beginning of the article. I think it would be helpful if this file was referenced here.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] If there is an issue related with this PR, point it out here.

## What is the current state of the documentation article?
The documentation was missing a needed file.

## What is the new state of the documentation article?
All files needed for the example are now directly in the article.

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

