### PR TITLE
docs: Issue with TS ES6 modules when inheriting from native

### DIFF
--- a/docs/core-concepts/ios-runtime/how-to/ObjC-Subclassing.md
+++ b/docs/core-concepts/ios-runtime/how-to/ObjC-Subclassing.md
@@ -181,6 +181,19 @@ class JSObject extends NSObject implements NSCoding {
 
 There should be no TypeScript constructor, because it will not be executed. Instead override one of the `init` methods.
 
+> **IMPORTANT NOTICE** Currently this syntax is unsupported when using TypeScript with **ES6 modules**. As a workaround you can
+> use the [JavaScript approach](#calling-base-methods-Subclass) by casting the base class to `any` and calling the [extend function](#extend)
+> like this:
+> ```typescript
+const AppDelegate = (UIResponder as any).extend({
+    applicationDidBecomeActive(application: UIApplication): void {
+        console.log("applicationDidBecomeActive", application);
+    }
+}, {
+    protocols: [UIApplicationDelegate]
+});
+> ```
+> For updates regarding this issue you can check [here](https://github.com/NativeScript/ios-runtime/issues/818)
 
 ## TypeScript Delegate Example
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] If there is an issue related with this PR, point it out here.

## What is the new state of the documentation article?
Added a note about the issue with inheriting native classes from TS with ES6 modules support

refs https://github.com/NativeScript/ios-runtime/issues/818

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

