### PR TITLE
chore: add hmr related warning when using RadSideDrawer as root view

### DIFF
--- a/docs/ui/professional-ui-components/SideDrawer/show-over-navi-bar.md
+++ b/docs/ui/professional-ui-components/SideDrawer/show-over-navi-bar.md
@@ -37,7 +37,7 @@ For example:
 
 By design when navigation is executed in the NativeScript application that navigation will be executed inside the `Frame` instance which means that the {% typedoc_link classes:RadSideDrawer %} instance will be persisted during that navigation.
 
-When using the {% typedoc_link classes:RadSideDrawer %} as a root element it will by design **always be shown over the navigation bar**. 
+When using the {% typedoc_link classes:RadSideDrawer %} as a root element it will by design **always be shown over the navigation bar**. Also please be aware that using {% typedoc_link classes:RadSideDrawer %} as a root element is **not compatible with HMR builds.**
 
 #### Figure 1. RadSideDrawer as a root element and over navigation bar (ActionBar)
 ![NativeScriptUI-Getting-Started-iOS](../../img/ns_ui/drawer-over-nav-ios.png "RadSideDrawer in iOS") ![NativeScriptUI-Getting-Started-Android](../../img/ns_ui/drawer-over-nav-android.png "RadSideDrawer in Android") 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] If there is an issue related with this PR, point it out here.

## What is the current state of the documentation article?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

There's no warning about HMR incompatibility with RadSideDrawer as root view. 

See: https://github.com/NativeScript/NativeScript/issues/6398

## What is the new state of the documentation article?
<!-- Describe the changes. -->

Now there is a warning.