### PR TITLE
Fix indentation and line breaks

### DIFF
--- a/docs/core-concepts/events.md
+++ b/docs/core-concepts/events.md
@@ -236,23 +236,28 @@ It is important to note that the `propertyChange` event is critical for the enti
 
 ``` JavaScript
 const observableModule = require("tns-core-modules/data/observable");
+
 var MyClass = (function (_super) {
   __extends(MyClass, _super);
+  
   function MyClass() {
     _super.apply(this, arguments);
   }
+  
   Object.defineProperty(MyClass.prototype, "myProperty", {
     get: function () {
       return this._myProperty;
-      },
-      set: function (value) {
-        this._myProperty = value;
-      },
-      enumerable: true,
-      configurable: true
-    });
-    return MyClass;
-  })(observableModule.Observable);
+    },
+    set: function (value) {
+      this._myProperty = value;
+    },
+    enumerable: true,
+    configurable: true
+  });
+  
+  return MyClass;
+})(observableModule.Observable);
+
 exports.MyClass = MyClass;
 ```
 ``` TypeScript

--- a/docs/core-concepts/memory-management.md
+++ b/docs/core-concepts/memory-management.md
@@ -21,7 +21,7 @@ In this article, we are explaining the life cycle of JavaScript and native insta
 
 **native instance** - Objective-C class instance (iOS) or Java class instance (Android).
 
-**reference counting** - the Objective-C runtime in iOS uses reference counting for lifetime management. Instances keep an internal counter which can be incremented and decremented. Each time a strong reference is set to point to an instance, the instance's reference count is incremented. Each time a strong reference is changed, the previous instance it pointed to, has its reference count decremented. When the count reaches 0, the instance is deallocated.
+**reference counting** - the Objective-C runtime in iOS uses reference counting for lifetime management. Instances keep an internal counter which can be incremented and decremented. Each time a strong reference is set to point to an instance, the instance's reference count is incremented. Each time a strong reference is changed, the previous instance it pointed to has its reference count decremented. When the count reaches 0, the instance is deallocated.
 
 **GC** - garbage collection in general. When GC runs, it first block the threads to find all strong instances from the stack. Then resumes execution until the GC marks all reachable objects in a separate thread. Then blocks again the threads to complete the marking. And in the end finalizes and deallocates the detected unreachable instances. While the actual GC implementation may be much more sophisticated, all implementations in virtual machines used for UI aim at minimizing the time the main thread is blocked. The Android Java VM, Android's V8 and iOS's JavaScriptCore are the three state of the art virtual machines used by NativeScript, which have garbage collectors.
 
@@ -39,7 +39,7 @@ The splices exhibit the following behavior:
  - Retrieve the native instance from a given JavaScript instance
  - Retrieve the JavaScript instance from a given native instance
  - Synchronize the life-cycle of the two instances
- - Proxy method calls, to and fro, the JavaScript and native instances
+ - Proxy method calls, to and from, the JavaScript and native instances
  - Throw exceptions, when methods are called, while in half-dead state
 
 A splice is created:
@@ -165,4 +165,4 @@ Here are some of the problems that still need to be addressed in the order of im
  - During a GC, the extra work required to traverse the JavaScript heap causes relatively big pauses on the main thread. E.g. for an Angular + {N} app with snapshot, each V8 GC can take up to half a second on a modern phone. We have introduced the `markingMode: "none"` option that involves no object graph traversing but has its pitfalls. For details see [the documentation article](./android-runtime/advanced-topics/memory-management.md#markingMode-none).
  - The cases of half-dead splices, although rare, are very hard to reproduce, track, debug, and fix.
  - Big objects take several V8 and Android VM GC passes to release, we could provide API to explicitly state that such objects will no longer be used and the reference to the Java instance will be made weak.
- - Regular splice objects, with no implementation object, cannot to extended with simple JavaScript properties. It would be useful if we could extend their lifetime to match the lifetime of the Java object.
+ - Regular splice objects, with no implementation object, cannot be extended with simple JavaScript properties. It would be useful if we could extend their lifetime to match the lifetime of the Java object.

--- a/docs/core-concepts/multithreading-model.md
+++ b/docs/core-concepts/multithreading-model.md
@@ -118,7 +118,7 @@ The way to spawn a Worker with webpack differs from the way described in the Web
 ```JavaScript
     ...
 
-   var workerScript = require("./workers/image-processor");
+   var WorkerScript = require("nativescript-worker-loader!./worker-script.js");
    var worker = new WorkerScript();
    worker.postMessage({ src: imageSource, mode: 'scale', options: options });
    


### PR DESCRIPTION
1 - Fix the indentation for the function and add line breaks for clarity of the code.
TS code for the same example is ok.

2 - Also fix small spelling errors in memory-management

3- With Webpack, the module needs to be required with the loader.
Check the worker-loader documentation:
https://github.com/NativeScript/worker-loader#web-workers-withwithout-webpack