### PR TITLE
docs(ns-setup-os-x): remove Xcode 7.x instructions

### DIFF
--- a/docs/start/ns-setup-os-x.md
+++ b/docs/start/ns-setup-os-x.md
@@ -23,7 +23,6 @@ This page contains a list of all system requirements needed to build and run Nat
     * xcodeproj ruby gem
     * CocoaPods
     * The `six` python package
-    * (Optional) xcproj command line tool
 * For Android development
     * JDK 8 or later
     * Latest official release of Android SDK
@@ -91,11 +90,6 @@ Complete the following steps to setup NativeScript on your macOS development mac
     6. Install python `six` package
 
         <pre class="add-copy-button"><code class="language-terminal">pip install six
-        </code></pre>
-
-    7. (Optional) If you are using Xcode 7.3 as well as an older version of CocoaPods (0.39.0 or earlier), you must install the `xcproj` command-line tool by running `brew install xcproj` in your terminal. You can check your CocoaPods version with pod --version.
-
-        <pre class="add-copy-button"><code class="language-terminal">brew install xcproj
         </code></pre>
 
 4. Install the dependencies for Android development.


### PR DESCRIPTION
Nativescript only supports Xcode 9+

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [X] If there is an issue related with this PR, point it out here.

## What is the current state of the documentation article?
Currently the documentation has instructions targeting Xcode 7.3.  

## What is the new state of the documentation article?
No more references to incompatible versions of Xcode.

