### PR TITLE
removing showOverNavigation option description from the articles

### DIFF
--- a/docs/app-and-screen-templates/creating-custom-templates.md
+++ b/docs/app-and-screen-templates/creating-custom-templates.md
@@ -316,7 +316,7 @@ Do follow a pattern that describes the custom component's feature. The recommend
     
     <!-- ... -->
 	
-    <nsDrawer:RadSideDrawer id="sideDrawer" showOverNavigation="true">
+    <nsDrawer:RadSideDrawer id="sideDrawer" >
         
 		<!-- ... -->
 

--- a/docs/ui/professional-ui-components/SideDrawer/programmatic.md
+++ b/docs/ui/professional-ui-components/SideDrawer/programmatic.md
@@ -17,11 +17,6 @@ The {% typedoc_link classes:RadSideDrawer,member:showDrawer() %} method is used 
 ## The `gesturesEnabled` Property
 Using the {% typedoc_link classes:RadSideDrawer,member:gesturesEnabled %} property you can prevent the end users from opening or closing the {% typedoc_link classes:RadSideDrawer %} using gestures.
 
-## The `showOverNavigation` Property
-Using the {% typedoc_link classes:RadSideDrawer,member:showOverNavigation %} property you can make {% typedoc_link classes:RadSideDrawer %} position its {% typedoc_link classes:RadSideDrawer,member:drawerContent %} view over or below the `ActionBar`.
-
-{% typedoc_link classes:RadSideDrawer %}'s {% typedoc_link classes:RadSideDrawer,member:drawerContent %} can be displayed above or under the action bar setting its {% typedoc_link classes:RadSideDrawer,member:showOverNavigation %} property.
-
 ## References
 Want to see more examples using **RadSideDrawer**?
 Check our SDK examples repository on GitHub. You will find this and a lot more practical examples with NativeScript UI.

--- a/docs/ui/professional-ui-components/ng-SideDrawer/programmatic.md
+++ b/docs/ui/professional-ui-components/ng-SideDrawer/programmatic.md
@@ -16,8 +16,3 @@ The {% typedoc_link classes:RadSideDrawer,member:showDrawer() %} method is used 
 
 ## The `gesturesEnabled` property
 Using the {% typedoc_link classes:RadSideDrawer,member:gesturesEnabled %} property you can prevent the end users from opening or closing the {% typedoc_link classes:RadSideDrawer %} using gestures.
-
-## The `showOverNavigation` property
-Using the {% typedoc_link classes:RadSideDrawer,member:showOverNavigation %} property you can make {% typedoc_link classes:RadSideDrawer %} position its {% typedoc_link classes:RadSideDrawer,member:drawerContent %} view over or below the `ActionBar`.
-
-{% typedoc_link classes:RadSideDrawer %}'s {% typedoc_link classes:RadSideDrawer,member:drawerContent %} can be displayed above or under the action bar setting its {% typedoc_link classes:RadSideDrawer,member:showOverNavigation %} property.


### PR DESCRIPTION
removing `showOverNavigation` option description from the articles