### PR TITLE
Update extend-application-activity.md

### DIFF
--- a/docs/core-concepts/android-runtime/advanced-topics/extend-application-activity.md
+++ b/docs/core-concepts/android-runtime/advanced-topics/extend-application-activity.md
@@ -117,7 +117,7 @@ The core modules ship with a default `android.support.v7.app.AppCompatActivity` 
                 frame.setActivityCallbacks(this);
             }
             // Modules will take care of calling super.onCreate, do not call it here
-            this._callbacks.onCreate(this, savedInstanceState, superProto.getIntent.call(this), superProto.onCreate);
+            this._callbacks.onCreate(this, savedInstanceState, this.getIntent(), superProto.onCreate);
 
             // Add custom initialization logic here
         },
@@ -161,7 +161,7 @@ The core modules ship with a default `android.support.v7.app.AppCompatActivity` 
                 setActivityCallbacks(this);
             }
 
-            this._callbacks.onCreate(this, savedInstanceState, super.onCreate);
+            this._callbacks.onCreate(this, savedInstanceState, this.getIntent(), super.onCreate);
         }
 
         public onSaveInstanceState(outState: android.os.Bundle): void {

--- a/docs/core-concepts/android-runtime/advanced-topics/extend-application-activity.md
+++ b/docs/core-concepts/android-runtime/advanced-topics/extend-application-activity.md
@@ -117,7 +117,7 @@ The core modules ship with a default `android.support.v7.app.AppCompatActivity` 
                 frame.setActivityCallbacks(this);
             }
             // Modules will take care of calling super.onCreate, do not call it here
-            this._callbacks.onCreate(this, savedInstanceState, superProto.onCreate);
+            this._callbacks.onCreate(this, savedInstanceState, superProto.getIntent.call(this), superProto.onCreate);
 
             // Add custom initialization logic here
         },


### PR DESCRIPTION
the old method signature was deprecated with NS 5.4
```AndroidActivityCallbacks.onCreate(activity: any, savedInstanceState: any, superFunc: Function) is deprecated. Use AndroidActivityCallbacks.onCreate(activity: any, savedInstanceState: any, intent: any, superFunc: Function) instead.```

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] If there is an issue related with this PR, point it out here.

## What is the current state of the documentation article?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new state of the documentation article?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

