### PR TITLE
style: update obsolete links

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ git clone https://github.com/NativeScript/nativescript-sdk-examples-js.git
 git clone https://github.com/NativeScript/nativescript-sdk-examples-ng.git
 git clone https://github.com/NativeScript/nativescript-cli.git
 
-git clone https://github.com/telerik/nativescript-ui-samples.git
-git clone https://github.com/telerik/nativescript-ui-samples-angular.git
-git clone https://github.com/telerik/nativescript-ui-samples-vue.git
+git clone https://github.com/NativeScript/nativescript-ui-samples.git
+git clone https://github.com/NativeScript/nativescript-ui-samples-angular.git
+git clone https://github.com/NativeScript/nativescript-ui-samples-vue.git
 ```
 
 > **NOTE**: `nativescript-ui-...` are private repositories used for building the Api Reference for the NativeScript UI components.  

--- a/docs/performance-optimizations/bundling-with-webpack.md
+++ b/docs/performance-optimizations/bundling-with-webpack.md
@@ -358,6 +358,6 @@ Apps using the nativescript-dev-webpack plugin:
 
 * [Groceries](https://github.com/NativeScript/sample-Groceries)
 * [NativeScript SDK Examples](https://github.com/NativeScript/nativescript-sdk-examples-ng)
-* [NativeScript-UI SDK Examples](https://github.com/telerik/nativescript-ui-samples-angular)
+* [NativeScript-UI SDK Examples](https://github.com/NativeScript/nativescript-ui-samples-angular)
 * [Cosmos Databank](https://github.com/NickIliev/nativescript-ng-cosmos)
 * [Tests app NG](https://github.com/NativeScript/tests-app-ng)

--- a/docs/releases/changes.md
+++ b/docs/releases/changes.md
@@ -26,10 +26,10 @@ NativeScript consists of several parts that ideally, would get released at their
 ## Professional UI Components - NativeScript UI
 Since version 3.5.0, `nativescript-pro-ui` is deperecated and each component has been moved to its [own plugin](https://www.nativescript.org/blog/professional-components-from-nativescript-ui-the-big-breakup). Below are the links for the release notes of each of the plugins. In case you need to migrate, read the relevant [migration documentation]({% slug nativescript-ui-migration %}).
 
--  [AutoComplete](https://github.com/telerik/nativescript-ui-feedback/blob/master/releases/autocomplete.md)
--  [Calendar](https://github.com/telerik/nativescript-ui-feedback/blob/master/releases/calendar.md)
--  [Chart](https://github.com/telerik/nativescript-ui-feedback/blob/master/releases/chart.md)
--  [DataForm](https://github.com/telerik/nativescript-ui-feedback/blob/master/releases/dataform.md)
--  [Gauge](https://github.com/telerik/nativescript-ui-feedback/blob/master/releases/gauge.md)
--  [ListView](https://github.com/telerik/nativescript-ui-feedback/blob/master/releases/listview.md)
--  [SideDrawer](https://github.com/telerik/nativescript-ui-feedback/blob/master/releases/sidedrawer.md)
+-  [AutoComplete](https://github.com/NativeScript/nativescript-ui-feedback/blob/master/releases/autocomplete.md)
+-  [Calendar](https://github.com/NativeScript/nativescript-ui-feedback/blob/master/releases/calendar.md)
+-  [Chart](https://github.com/NativeScript/nativescript-ui-feedback/blob/master/releases/chart.md)
+-  [DataForm](https://github.com/NativeScript/nativescript-ui-feedback/blob/master/releases/dataform.md)
+-  [Gauge](https://github.com/NativeScript/nativescript-ui-feedback/blob/master/releases/gauge.md)
+-  [ListView](https://github.com/NativeScript/nativescript-ui-feedback/blob/master/releases/listview.md)
+-  [SideDrawer](https://github.com/NativeScript/nativescript-ui-feedback/blob/master/releases/sidedrawer.md)

--- a/docs/ui/professional-ui-components/AutoCompleteTextView/autocomplete-aync-data.md
+++ b/docs/ui/professional-ui-components/AutoCompleteTextView/autocomplete-aync-data.md
@@ -44,5 +44,5 @@ it will use the returned items to complete it's population.
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Remote Data Fetch Example](https://github.com/telerik/nativescript-ui-samples/tree/master/autocomplete/app/examples/remote-data-fetch)
+* [Remote Data Fetch Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/autocomplete/app/examples/remote-data-fetch)
 

--- a/docs/ui/professional-ui-components/AutoCompleteTextView/autocomplete-completion-modes.md
+++ b/docs/ui/professional-ui-components/AutoCompleteTextView/autocomplete-completion-modes.md
@@ -32,7 +32,7 @@ The completion mode `Contains` is not intended to work with the `Append` and  `S
 Want to see more examples using **RadAutoCompleteTextView**?
 Check our SDK examples repository on GitHub. You will find this and a lot more practical examples with NativeScript UI.
 
-* [RadAutoCompleteTextView Examples](https://github.com/telerik/nativescript-ui-samples/tree/master/autocomplete/app/examples/)
+* [RadAutoCompleteTextView Examples](https://github.com/NativeScript/nativescript-ui-samples/tree/master/autocomplete/app/examples/)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/AutoCompleteTextView/autocomplete-display-modes.md
+++ b/docs/ui/professional-ui-components/AutoCompleteTextView/autocomplete-display-modes.md
@@ -45,7 +45,7 @@ In horizontal mode tokens are displayed on single line which can be scrolled hor
 Want to see more examples using **RadAutoCompleteTextView**?
 Check our SDK examples repository on GitHub. You will find this and a lot more practical examples with NativeScript UI.
 
-* [RadAutoCompleteTextView Examples](https://github.com/telerik/nativescript-ui-samples/tree/master/autocomplete/app/examples/)
+* [RadAutoCompleteTextView Examples](https://github.com/NativeScript/nativescript-ui-samples/tree/master/autocomplete/app/examples/)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/AutoCompleteTextView/autocomplete-events.md
+++ b/docs/ui/professional-ui-components/AutoCompleteTextView/autocomplete-events.md
@@ -36,4 +36,4 @@ In order to get notified when one of the above-mentioned events occur, you shoul
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Events Examples](https://github.com/telerik/nativescript-ui-samples/tree/master/autocomplete/app/examples/events)
+* [Events Examples](https://github.com/NativeScript/nativescript-ui-samples/tree/master/autocomplete/app/examples/events)

--- a/docs/ui/professional-ui-components/AutoCompleteTextView/autocomplete-getting-started.md
+++ b/docs/ui/professional-ui-components/AutoCompleteTextView/autocomplete-getting-started.md
@@ -48,5 +48,5 @@ The `suggestionItemTemplate` is the holder which is used to produce layout for e
 Want to see more examples using **RadAutoCompleteTextView**?
 Check our SDK examples repository on GitHub. You will find this and a lot more practical examples with NativeScript UI.
 
-* [RadAutoCompleteTextView Examples](https://github.com/telerik/nativescript-ui-samples/tree/master/autocomplete/app/examples/)
+* [RadAutoCompleteTextView Examples](https://github.com/NativeScript/nativescript-ui-samples/tree/master/autocomplete/app/examples/)
 

--- a/docs/ui/professional-ui-components/AutoCompleteTextView/autocomplete-suggest-modes.md
+++ b/docs/ui/professional-ui-components/AutoCompleteTextView/autocomplete-suggest-modes.md
@@ -34,7 +34,7 @@ In `SuggestAppend` mode the autocomplete combines both upper-mentioned modes. It
 Want to see more examples using **RadAutoCompleteTextView**?
 Check our SDK examples repository on GitHub. You will find this and a lot more practical examples with NativeScript UI.
 
-* [RadAutoCompleteTextView Examples](https://github.com/telerik/nativescript-ui-samples/tree/master/autocomplete/app/examples/)
+* [RadAutoCompleteTextView Examples](https://github.com/NativeScript/nativescript-ui-samples/tree/master/autocomplete/app/examples/)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/Calendar/Styling/day-view.md
+++ b/docs/ui/professional-ui-components/Calendar/Styling/day-view.md
@@ -40,7 +40,7 @@ This is how the calendar looks like in that case:
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Styling Example](https://github.com/telerik/nativescript-ui-samples/tree/master/calendar/app/calendar/cell-styling)
+* [Styling Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/calendar/app/calendar/cell-styling)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/Calendar/Styling/inlineevents.md
+++ b/docs/ui/professional-ui-components/Calendar/Styling/inlineevents.md
@@ -39,7 +39,7 @@ and the visual result:
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Styling Example](https://github.com/telerik/nativescript-ui-samples/tree/master/calendar/app/calendar/cell-styling)
+* [Styling Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/calendar/app/calendar/cell-styling)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/Calendar/Styling/month-view.md
+++ b/docs/ui/professional-ui-components/Calendar/Styling/month-view.md
@@ -74,7 +74,7 @@ This is how the calendar looks like:
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Styling Example](https://github.com/telerik/nativescript-ui-samples/tree/master/calendar/app/calendar/cell-styling)
+* [Styling Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/calendar/app/calendar/cell-styling)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/Calendar/Styling/monthnames-view.md
+++ b/docs/ui/professional-ui-components/Calendar/Styling/monthnames-view.md
@@ -27,7 +27,7 @@ This is how the calendar looks like now:
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Styling Example](https://github.com/telerik/nativescript-ui-samples/tree/master/calendar/app/calendar/cell-styling)
+* [Styling Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/calendar/app/calendar/cell-styling)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/Calendar/Styling/week-view.md
+++ b/docs/ui/professional-ui-components/Calendar/Styling/week-view.md
@@ -22,7 +22,7 @@ Here's a code snippet demonstrating the usage of the properties of the Style obj
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Styling Example](https://github.com/telerik/nativescript-ui-samples/tree/master/calendar/app/calendar/cell-styling)
+* [Styling Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/calendar/app/calendar/cell-styling)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/Calendar/Styling/year-view.md
+++ b/docs/ui/professional-ui-components/Calendar/Styling/year-view.md
@@ -57,7 +57,7 @@ This is how the calendar looks like in that case:
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Styling Example](https://github.com/telerik/nativescript-ui-samples/tree/master/calendar/app/calendar/cell-styling)
+* [Styling Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/calendar/app/calendar/cell-styling)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/Calendar/event-handling.md
+++ b/docs/ui/professional-ui-components/Calendar/event-handling.md
@@ -53,7 +53,7 @@ All events exposed by {% typedoc_link classes:RadCalendar %} provide additional 
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Event-handlers Example](https://github.com/telerik/nativescript-ui-samples/tree/master/calendar/app/calendar/events)
+* [Event-handlers Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/calendar/app/calendar/events)
 	
 	
 

--- a/docs/ui/professional-ui-components/Calendar/getting-started.md
+++ b/docs/ui/professional-ui-components/Calendar/getting-started.md
@@ -37,4 +37,4 @@ This will initialize a new {% typedoc_link classes:RadCalendar %} instance and p
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Getting Started Example](https://github.com/telerik/nativescript-ui-samples/tree/master/calendar/app/calendar/getting-started)
+* [Getting Started Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/calendar/app/calendar/getting-started)

--- a/docs/ui/professional-ui-components/Calendar/localization.md
+++ b/docs/ui/professional-ui-components/Calendar/localization.md
@@ -24,4 +24,4 @@ The following two screenshots demonstrate how {% typedoc_link classes:RadCalenda
 Want to see this scenario in action?
 Check our SDK examples repository on GitHub. You will find this and a lot more practical examples with NativeScript UI.
 
-* [RadCalendar Localization Example](https://github.com/telerik/nativescript-ui-samples/tree/master/calendar/app/calendar/calendar-localization)
+* [RadCalendar Localization Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/calendar/app/calendar/calendar-localization)

--- a/docs/ui/professional-ui-components/Calendar/populating-with-data.md
+++ b/docs/ui/professional-ui-components/Calendar/populating-with-data.md
@@ -55,5 +55,5 @@ To change the events view mode you need to set the {% typedoc_link classes:RadCa
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Populating With Data Example](https://github.com/telerik/nativescript-ui-samples/tree/master/calendar/app/calendar/populating-with-data)
+* [Populating With Data Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/calendar/app/calendar/populating-with-data)
 

--- a/docs/ui/professional-ui-components/Calendar/transition-modes.md
+++ b/docs/ui/professional-ui-components/Calendar/transition-modes.md
@@ -28,5 +28,5 @@ publish: true
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Transition Modes Example](https://github.com/telerik/nativescript-ui-samples/tree/master/calendar/app/calendar/transition-modes)
+* [Transition Modes Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/calendar/app/calendar/transition-modes)
 

--- a/docs/ui/professional-ui-components/Calendar/view-modes.md
+++ b/docs/ui/professional-ui-components/Calendar/view-modes.md
@@ -25,4 +25,4 @@ publish: true
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [View Modes Example](https://github.com/telerik/nativescript-ui-samples/tree/master/calendar/app/calendar/view-modes)
+* [View Modes Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/calendar/app/calendar/view-modes)

--- a/docs/ui/professional-ui-components/Chart/Axes/axes.md
+++ b/docs/ui/professional-ui-components/Chart/Axes/axes.md
@@ -31,5 +31,5 @@ The axes that can be used to visualize the value of a data point extend the Nume
 Want to see more examples using **RadCartesianChart**?
 Check our SDK examples repository on GitHub. You will find this and a lot more practical examples with NativeScript UI.
 
-* [Axes Examples](https://github.com/telerik/nativescript-ui-samples/tree/master/chart/app/examples/axes)
+* [Axes Examples](https://github.com/NativeScript/nativescript-ui-samples/tree/master/chart/app/examples/axes)
  

--- a/docs/ui/professional-ui-components/Chart/Axes/categorical.md
+++ b/docs/ui/professional-ui-components/Chart/Axes/categorical.md
@@ -36,7 +36,7 @@ This is how the axis in this example looks like:
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Categorical Axis Example](https://github.com/telerik/nativescript-ui-samples/tree/master/chart/app/examples/series/area)
+* [Categorical Axis Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/chart/app/examples/series/area)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/Chart/Axes/datetimecategorical.md
+++ b/docs/ui/professional-ui-components/Chart/Axes/datetimecategorical.md
@@ -30,7 +30,7 @@ Defines the format of the Calendar structure that will be used for the categorie
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Axes Examples](https://github.com/telerik/nativescript-ui-samples/tree/master/chart/app/examples/axes)
+* [Axes Examples](https://github.com/NativeScript/nativescript-ui-samples/tree/master/chart/app/examples/axes)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/Chart/Axes/datetimecontinuous.md
+++ b/docs/ui/professional-ui-components/Chart/Axes/datetimecontinuous.md
@@ -19,7 +19,7 @@ When [RadCartesianChart]({% slug chart-types-cartesian-angular%}) visualizes {% 
 > When binding the chart to data that contains Date objects, developers need to convert these date objects to time in **milliseconds**. 
 
 This is necessary because the Telerik UI library calls JSON.stringify() on the data objects before they are passed to the underlying native implementation. Then, the native implementation
-parses back the string to a native Android or iOS object. This call to stringify may produce incorrect results when called on a Date object. To be safe, convert the Date data beforehand to time in milliseconds. For more details take a look at our "Date time axis" example from our sdk repository [here](https://github.com/telerik/nativescript-ui-samples/tree/master/chart/app/examples/axes/date-time-axes)
+parses back the string to a native Android or iOS object. This call to stringify may produce incorrect results when called on a Date object. To be safe, convert the Date data beforehand to time in milliseconds. For more details take a look at our "Date time axis" example from our sdk repository [here](https://github.com/NativeScript/nativescript-ui-samples/tree/master/chart/app/examples/axes/date-time-axes)
 
 ### Features
 
@@ -51,7 +51,7 @@ You can get and set the current value with the {% typedoc_link classes:Categoric
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [DateTime Continuous Axis Examples](https://github.com/telerik/nativescript-ui-samples/tree/master/chart/app/examples/axes/date-time-axes)
+* [DateTime Continuous Axis Examples](https://github.com/NativeScript/nativescript-ui-samples/tree/master/chart/app/examples/axes/date-time-axes)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/Chart/Axes/linear.md
+++ b/docs/ui/professional-ui-components/Chart/Axes/linear.md
@@ -33,7 +33,7 @@ Defines the minimum available value. To get or set the maximum use the {% typedo
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Axes Examples](https://github.com/telerik/nativescript-ui-samples/tree/master/chart/app/examples/axes)
+* [Axes Examples](https://github.com/NativeScript/nativescript-ui-samples/tree/master/chart/app/examples/axes)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/Chart/Axes/negative-values.md
+++ b/docs/ui/professional-ui-components/Chart/Axes/negative-values.md
@@ -24,7 +24,7 @@ This is how the chart will look like with negative values on the Y axis:
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Negative Values Example](https://github.com/telerik/nativescript-ui-samples/tree/master/chart/app/examples/axes/negative-values)
+* [Negative Values Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/chart/app/examples/axes/negative-values)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/Chart/Axes/styling.md
+++ b/docs/ui/professional-ui-components/Chart/Axes/styling.md
@@ -37,7 +37,7 @@ This is how the chart looks like now:
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Customization Example](https://github.com/telerik/nativescript-ui-samples/tree/master/chart/app/examples/axes/customization)
+* [Customization Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/chart/app/examples/axes/customization)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/Chart/Behaviors/annotations.md
+++ b/docs/ui/professional-ui-components/Chart/Behaviors/annotations.md
@@ -84,5 +84,5 @@ Android:
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Annotations Examples](https://github.com/telerik/nativescript-ui-samples/tree/master/chart/app/examples/annotations)
+* [Annotations Examples](https://github.com/NativeScript/nativescript-ui-samples/tree/master/chart/app/examples/annotations)
 

--- a/docs/ui/professional-ui-components/Chart/Behaviors/pan-and-zoom.md
+++ b/docs/ui/professional-ui-components/Chart/Behaviors/pan-and-zoom.md
@@ -40,7 +40,7 @@ With the following example you can see that pan & zoom  properties could be used
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Behaviors Examples](https://github.com/telerik/nativescript-ui-samples/tree/master/chart/app/examples/behaviors)
+* [Behaviors Examples](https://github.com/NativeScript/nativescript-ui-samples/tree/master/chart/app/examples/behaviors)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/Chart/Behaviors/selection.md
+++ b/docs/ui/professional-ui-components/Chart/Behaviors/selection.md
@@ -50,7 +50,7 @@ The following example demonstrates how to enable series selection
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Behaviors Examples](https://github.com/telerik/nativescript-ui-samples/tree/master/chart/app/examples/behaviors)
+* [Behaviors Examples](https://github.com/NativeScript/nativescript-ui-samples/tree/master/chart/app/examples/behaviors)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/Chart/Behaviors/trackball.md
+++ b/docs/ui/professional-ui-components/Chart/Behaviors/trackball.md
@@ -43,4 +43,4 @@ You can customize the content within the trackball by using the {% typedoc_link 
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Trackball Example](https://github.com/telerik/nativescript-ui-samples/tree/master/chart/app/examples/behaviors)
+* [Trackball Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/chart/app/examples/behaviors)

--- a/docs/ui/professional-ui-components/Chart/Grid/grid.md
+++ b/docs/ui/professional-ui-components/Chart/Grid/grid.md
@@ -44,4 +44,4 @@ Just like the Stroke color, {% typedoc_link classes:RadCartesianChartGrid %} off
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Styling Examples](https://github.com/telerik/nativescript-ui-samples/tree/master/chart/app/examples/styling)
+* [Styling Examples](https://github.com/NativeScript/nativescript-ui-samples/tree/master/chart/app/examples/styling)

--- a/docs/ui/professional-ui-components/Chart/Grid/styling.md
+++ b/docs/ui/professional-ui-components/Chart/Grid/styling.md
@@ -47,4 +47,4 @@ Android:
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Styling Examples](https://github.com/telerik/nativescript-ui-samples/tree/master/chart/app/examples/styling)
+* [Styling Examples](https://github.com/NativeScript/nativescript-ui-samples/tree/master/chart/app/examples/styling)

--- a/docs/ui/professional-ui-components/Chart/Labels/labels.md
+++ b/docs/ui/professional-ui-components/Chart/Labels/labels.md
@@ -33,4 +33,4 @@ All axes have properties which provide various customization options for the lab
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Styling Examples](https://github.com/telerik/nativescript-ui-samples/tree/master/chart/app/examples/styling)
+* [Styling Examples](https://github.com/NativeScript/nativescript-ui-samples/tree/master/chart/app/examples/styling)

--- a/docs/ui/professional-ui-components/Chart/Labels/styling.md
+++ b/docs/ui/professional-ui-components/Chart/Labels/styling.md
@@ -44,4 +44,4 @@ All axes have their default labels. They are visible by default. In order to dis
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Styling Examples](https://github.com/telerik/nativescript-ui-samples/tree/master/chart/app/examples/styling)
+* [Styling Examples](https://github.com/NativeScript/nativescript-ui-samples/tree/master/chart/app/examples/styling)

--- a/docs/ui/professional-ui-components/Chart/Legend/legend.md
+++ b/docs/ui/professional-ui-components/Chart/Legend/legend.md
@@ -42,4 +42,4 @@ The following images demonstrate how this setup looks like in a running applicat
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Legend Examples](https://github.com/telerik/nativescript-ui-samples/tree/master/chart/app/examples/legend)
+* [Legend Examples](https://github.com/NativeScript/nativescript-ui-samples/tree/master/chart/app/examples/legend)

--- a/docs/ui/professional-ui-components/Chart/Series/Financial/candlestick.md
+++ b/docs/ui/professional-ui-components/Chart/Series/Financial/candlestick.md
@@ -34,7 +34,7 @@ And finally, in the XML definition of the page we put a RadCartesianChart, add a
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Financial Series Examples](https://github.com/telerik/nativescript-ui-samples/tree/master/chart/app/examples/series/financial)
+* [Financial Series Examples](https://github.com/NativeScript/nativescript-ui-samples/tree/master/chart/app/examples/series/financial)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/Chart/Series/Financial/ohlc.md
+++ b/docs/ui/professional-ui-components/Chart/Series/Financial/ohlc.md
@@ -34,7 +34,7 @@ And finally, in the XML definition of the page we put a RadCartesianChart, add a
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Financial Series Examples](https://github.com/telerik/nativescript-ui-samples/tree/master/chart/app/examples/series/financial)
+* [Financial Series Examples](https://github.com/NativeScript/nativescript-ui-samples/tree/master/chart/app/examples/series/financial)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/Chart/Series/area.md
+++ b/docs/ui/professional-ui-components/Chart/Series/area.md
@@ -30,7 +30,7 @@ And finally, in the XML definition of the page we put a `RadCartesianChart`, add
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Series Examples](https://github.com/telerik/nativescript-ui-samples/tree/master/chart/app/examples/series)
+* [Series Examples](https://github.com/NativeScript/nativescript-ui-samples/tree/master/chart/app/examples/series)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/Chart/Series/bar.md
+++ b/docs/ui/professional-ui-components/Chart/Series/bar.md
@@ -37,7 +37,7 @@ And finally, in the XML definition of the page we put a RadCartesianChart, add a
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Series Examples](https://github.com/telerik/nativescript-ui-samples/tree/master/chart/app/examples/series)
+* [Series Examples](https://github.com/NativeScript/nativescript-ui-samples/tree/master/chart/app/examples/series)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/Chart/Series/bubble.md
+++ b/docs/ui/professional-ui-components/Chart/Series/bubble.md
@@ -33,7 +33,7 @@ And finally, in the XML definition of the page we put a {% typedoc_link classes:
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Series Examples](https://github.com/telerik/nativescript-ui-samples/tree/master/chart/app/examples/series)
+* [Series Examples](https://github.com/NativeScript/nativescript-ui-samples/tree/master/chart/app/examples/series)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/Chart/Series/line.md
+++ b/docs/ui/professional-ui-components/Chart/Series/line.md
@@ -31,7 +31,7 @@ Here's how your Line chart should look like:
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Series Examples](https://github.com/telerik/nativescript-ui-samples/tree/master/chart/app/examples/series)
+* [Series Examples](https://github.com/NativeScript/nativescript-ui-samples/tree/master/chart/app/examples/series)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/Chart/Series/pie.md
+++ b/docs/ui/professional-ui-components/Chart/Series/pie.md
@@ -31,7 +31,7 @@ This is how the example looks like:
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Series Examples](https://github.com/telerik/nativescript-ui-samples/tree/master/chart/app/examples/series)
+* [Series Examples](https://github.com/NativeScript/nativescript-ui-samples/tree/master/chart/app/examples/series)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/Chart/Series/range-bar.md
+++ b/docs/ui/professional-ui-components/Chart/Series/range-bar.md
@@ -32,7 +32,7 @@ Depending on the required Bar orientation, you can swap the axes' position and a
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Series Examples](https://github.com/telerik/nativescript-ui-samples/tree/master/chart/app/examples/series)
+* [Series Examples](https://github.com/NativeScript/nativescript-ui-samples/tree/master/chart/app/examples/series)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/Chart/Series/scatter-bubble.md
+++ b/docs/ui/professional-ui-components/Chart/Series/scatter-bubble.md
@@ -33,7 +33,7 @@ And finally, in the XML definition of the page we put a {% typedoc_link classes:
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Series Examples](https://github.com/telerik/nativescript-ui-samples/tree/master/chart/app/examples/series)
+* [Series Examples](https://github.com/NativeScript/nativescript-ui-samples/tree/master/chart/app/examples/series)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/Chart/Series/scatter.md
+++ b/docs/ui/professional-ui-components/Chart/Series/scatter.md
@@ -33,7 +33,7 @@ And finally, in the XML definition of the page we put a {% typedoc_link classes:
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Series Examples](https://github.com/telerik/nativescript-ui-samples/tree/master/chart/app/examples/series)
+* [Series Examples](https://github.com/NativeScript/nativescript-ui-samples/tree/master/chart/app/examples/series)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/Chart/Series/spline-area.md
+++ b/docs/ui/professional-ui-components/Chart/Series/spline-area.md
@@ -30,7 +30,7 @@ And finally, in the XML definition of the page we put a {% typedoc_link classes:
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Series Examples](https://github.com/telerik/nativescript-ui-samples/tree/master/chart/app/examples/series)
+* [Series Examples](https://github.com/NativeScript/nativescript-ui-samples/tree/master/chart/app/examples/series)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/Chart/Series/spline.md
+++ b/docs/ui/professional-ui-components/Chart/Series/spline.md
@@ -30,7 +30,7 @@ And finally, in the XML definition of the page we put a {% typedoc_link classes:
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Series Examples](https://github.com/telerik/nativescript-ui-samples/tree/master/chart/app/examples/series)
+* [Series Examples](https://github.com/NativeScript/nativescript-ui-samples/tree/master/chart/app/examples/series)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/Chart/Series/styling.md
+++ b/docs/ui/professional-ui-components/Chart/Series/styling.md
@@ -52,4 +52,4 @@ And here's the result on android (on the left) and on iOS (on the right):
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Styling Examples](https://github.com/telerik/nativescript-ui-samples/tree/master/chart/app/examples/styling)
+* [Styling Examples](https://github.com/NativeScript/nativescript-ui-samples/tree/master/chart/app/examples/styling)

--- a/docs/ui/professional-ui-components/Chart/getting-started.md
+++ b/docs/ui/professional-ui-components/Chart/getting-started.md
@@ -47,4 +47,4 @@ This will produce a page showing a Chart that will look like:
 Want to see more examples using **RadCartesianChart**?
 Check our SDK examples repository on GitHub. You will find this and a lot more practical examples with NativeScript UI.
 
-* [Chart Examples](https://github.com/telerik/nativescript-ui-samples/tree/master/chart/app/examples)
+* [Chart Examples](https://github.com/NativeScript/nativescript-ui-samples/tree/master/chart/app/examples)

--- a/docs/ui/professional-ui-components/DataForm/Editors/dataform-editors-custom.md
+++ b/docs/ui/professional-ui-components/DataForm/Editors/dataform-editors-custom.md
@@ -58,9 +58,9 @@ We have created a helper class which exposes a `handleTap` method that will be e
 ## References
 
 Want to see this scenario in action?
-Check our [SDK examples](https://github.com/telerik/nativescript-ui-samples) repo on GitHub. You will find this and many other practical examples with NativeScript UI.
+Check our [SDK examples](https://github.com/NativeScript/nativescript-ui-samples) repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Custom Editors Example](https://github.com/telerik/nativescript-ui-samples/tree/master/dataform/app/examples/editors/custom-editors)
+* [Custom Editors Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/dataform/app/examples/editors/custom-editors)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/DataForm/Editors/dataform-editors-list.md
+++ b/docs/ui/professional-ui-components/DataForm/Editors/dataform-editors-list.md
@@ -225,11 +225,11 @@ If an editor that you would like to use is not included in the list with predefi
 ## References
 
 Want to see this scenario in action?
-Check our [SDK Examples](https://github.com/telerik/nativescript-ui-samples) repo on GitHub. You will find this and many other practical examples with NativeScript UI.
+Check our [SDK Examples](https://github.com/NativeScript/nativescript-ui-samples) repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Editors Common Example](https://github.com/telerik/nativescript-ui-samples/tree/master/dataform/app/examples/editors)
-* [Editors AutoComplete Example](https://github.com/telerik/nativescript-ui-samples/tree/master/dataform/app/examples/editors/autocomplete)
-* [Editors Labels Example](https://github.com/telerik/nativescript-ui-samples/tree/master/dataform/app/examples/editors/labels)
+* [Editors Common Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/dataform/app/examples/editors)
+* [Editors AutoComplete Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/dataform/app/examples/editors/autocomplete)
+* [Editors Labels Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/dataform/app/examples/editors/labels)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/DataForm/Editors/dataform-editors-overview.md
+++ b/docs/ui/professional-ui-components/DataForm/Editors/dataform-editors-overview.md
@@ -61,10 +61,10 @@ You can find the list with all available editors [here]({% slug dataform-editors
 ## References
 
 Want to see these scenarios in action?
-Check our [SDK Examples](https://github.com/telerik/nativescript-ui-samples) repo on GitHub. You will find these and many other practical examples with NativeScript UI.
+Check our [SDK Examples](https://github.com/NativeScript/nativescript-ui-samples) repo on GitHub. You will find these and many other practical examples with NativeScript UI.
 
-* [Editors Common Example](https://github.com/telerik/nativescript-ui-samples/tree/master/dataform/app/examples/editors)
-* [Runtime Updates Example](https://github.com/telerik/nativescript-ui-samples/tree/master/dataform/app/examples/runtime-updates)
+* [Editors Common Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/dataform/app/examples/editors)
+* [Runtime Updates Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/dataform/app/examples/runtime-updates)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/DataForm/Editors/dataform-editors-providers.md
+++ b/docs/ui/professional-ui-components/DataForm/Editors/dataform-editors-providers.md
@@ -69,10 +69,10 @@ If you want to use an `Array` with your custom objects and they don't have `key`
 ## References
 
 Want to see these scenarios in action?
-Check our [SDK Examples](https://github.com/telerik/nativescript-ui-samples) repo on GitHub. You will find these and many other practical examples with NativeScript UI.
+Check our [SDK Examples](https://github.com/NativeScript/nativescript-ui-samples) repo on GitHub. You will find these and many other practical examples with NativeScript UI.
 
-* [Value Providers Example](https://github.com/telerik/nativescript-ui-samples/tree/master/dataform/app/examples/value-providers)
-* [Editors Common Example](https://github.com/telerik/nativescript-ui-samples/tree/master/dataform/app/examples/editors)
+* [Value Providers Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/dataform/app/examples/value-providers)
+* [Editors Common Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/dataform/app/examples/editors)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/DataForm/GettingStarted/dataform-start-properties.md
+++ b/docs/ui/professional-ui-components/DataForm/GettingStarted/dataform-start-properties.md
@@ -145,11 +145,11 @@ Our next step is to determine the values of the source object reflecting the cha
 ## References
 
 Want to see these scenarios in action?
-Check our [SDK Examples](https://github.com/telerik/nativescript-ui-samples) repo on GitHub. You will find these and many other practical examples with NativeScript UI.
+Check our [SDK Examples](https://github.com/NativeScript/nativescript-ui-samples) repo on GitHub. You will find these and many other practical examples with NativeScript UI.
 
-* [Properties Example](https://github.com/telerik/nativescript-ui-samples/tree/master/dataform/app/examples/adjustment)
-* [Runtime Updates Example](https://github.com/telerik/nativescript-ui-samples/tree/master/dataform/app/examples/runtime-updates)
-* [Properties JSON Example](https://github.com/telerik/nativescript-ui-samples/tree/master/dataform/app/examples/metadata)
+* [Properties Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/dataform/app/examples/adjustment)
+* [Runtime Updates Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/dataform/app/examples/runtime-updates)
+* [Properties JSON Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/dataform/app/examples/metadata)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/DataForm/GettingStarted/dataform-start-result.md
+++ b/docs/ui/professional-ui-components/DataForm/GettingStarted/dataform-start-result.md
@@ -46,11 +46,11 @@ The other event - **propertyCommitted** - is called after the property is commit
 ## References
 
 Want to see these scenarios in action?
-Check our [SDK Examples](https://github.com/telerik/nativescript-ui-samples) repo on GitHub. You will find these and many other practical examples with NativeScript UI.
+Check our [SDK Examples](https://github.com/NativeScript/nativescript-ui-samples) repo on GitHub. You will find these and many other practical examples with NativeScript UI.
 
-* [Commit Modes Example](https://github.com/telerik/nativescript-ui-samples/tree/master/dataform/app/examples/commit-modes)
-* [Events Example](https://github.com/telerik/nativescript-ui-samples/tree/master/dataform/app/examples/events)
-* [Scrollable Form Example](https://github.com/telerik/nativescript-ui-samples/tree/master/dataform/app/examples/scrolling)
+* [Commit Modes Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/dataform/app/examples/commit-modes)
+* [Events Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/dataform/app/examples/events)
+* [Scrollable Form Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/dataform/app/examples/scrolling)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/DataForm/GettingStarted/dataform-start-source.md
+++ b/docs/ui/professional-ui-components/DataForm/GettingStarted/dataform-start-source.md
@@ -59,10 +59,10 @@ Our next step is to adjust the editors that are used for each of the source obje
 ## References
 
 Want to see these scenarios in action?
-Check our [SDK Examples](https://github.com/telerik/nativescript-ui-samples) repo on GitHub. You will find these and many other practical examples with NativeScript UI.
+Check our [SDK Examples](https://github.com/NativeScript/nativescript-ui-samples) repo on GitHub. You will find these and many other practical examples with NativeScript UI.
 
-* [Getting Started Example](https://github.com/telerik/nativescript-ui-samples/tree/master/dataform/app/examples/getting-started)
-* [Getting Started JSON Example](https://github.com/telerik/nativescript-ui-samples/tree/master/dataform/app/examples/getting-started-json)
+* [Getting Started Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/dataform/app/examples/getting-started)
+* [Getting Started JSON Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/dataform/app/examples/getting-started-json)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/DataForm/Groups/dataform-groups-layouts.md
+++ b/docs/ui/professional-ui-components/DataForm/Groups/dataform-groups-layouts.md
@@ -49,9 +49,9 @@ In order to specify where each editor is placed in the {% typedoc_link classes:D
 ## References
 
 Want to see this scenario in action?
-Check our [SDK Examples](https://github.com/telerik/nativescript-ui-samples) repo on GitHub. You will find this and many other practical examples with NativeScript UI.
+Check our [SDK Examples](https://github.com/NativeScript/nativescript-ui-samples) repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Layouts Example](https://github.com/telerik/nativescript-ui-samples/tree/master/dataform/app/examples/layouts)
+* [Layouts Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/dataform/app/examples/layouts)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/DataForm/Groups/dataform-groups-overview.md
+++ b/docs/ui/professional-ui-components/DataForm/Groups/dataform-groups-overview.md
@@ -114,10 +114,10 @@ public onGroupUpdate(args) {
 ## References
 
 Want to see this scenario in action?
-Check our [SDK Examples](https://github.com/telerik/nativescript-ui-samples) repo on GitHub. You will find this and many other practical examples with NativeScript UI.
+Check our [SDK Examples](https://github.com/NativeScript/nativescript-ui-samples) repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Groups Example](https://github.com/telerik/nativescript-ui-samples/tree/master/dataform/app/examples/groups)
-* [Runtime Updates Example](https://github.com/telerik/nativescript-ui-samples/tree/master/dataform/app/examples/runtime-updates)
+* [Groups Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/dataform/app/examples/groups)
+* [Runtime Updates Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/dataform/app/examples/runtime-updates)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/DataForm/Validation/dataform-validation-custom.md
+++ b/docs/ui/professional-ui-components/DataForm/Validation/dataform-validation-custom.md
@@ -53,10 +53,10 @@ Let's walk through that implementation. First, we are getting each `EntityProper
 ## References
 
 Want to see this scenario in action?
-Check our [SDK Examples](https://github.com/telerik/nativescript-ui-samples) repo on GitHub. You will find these and many other practical examples with NativeScript UI.
+Check our [SDK Examples](https://github.com/NativeScript/nativescript-ui-samples) repo on GitHub. You will find these and many other practical examples with NativeScript UI.
 
-* [Custom Validator Example](https://github.com/telerik/nativescript-ui-samples/tree/master/dataform/app/examples/validation/custom-validator)
-* [Custom Validation Example](https://github.com/telerik/nativescript-ui-samples/tree/master/dataform/app/examples/validation/custom-validation)
+* [Custom Validator Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/dataform/app/examples/validation/custom-validator)
+* [Custom Validation Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/dataform/app/examples/validation/custom-validation)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/DataForm/Validation/dataform-validation-events.md
+++ b/docs/ui/professional-ui-components/DataForm/Validation/dataform-validation-events.md
@@ -63,10 +63,10 @@ The **propertyValidated** event gives you an opportunity to get notified that a 
 ## References
 
 Want to see these scenarios in action?
-Check our [SDK examples](https://github.com/telerik/nativescript-ui-samples) repo on GitHub. You will find these and many other practical examples with NativeScript UI.
+Check our [SDK examples](https://github.com/NativeScript/nativescript-ui-samples) repo on GitHub. You will find these and many other practical examples with NativeScript UI.
 
-* [Validation Events Example](https://github.com/telerik/nativescript-ui-samples/tree/master/dataform/app/examples/validation/validation-events)
-* [Async Validation Example](https://github.com/telerik/nativescript-ui-samples/tree/master/dataform/app/examples/validation/async-validation)
+* [Validation Events Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/dataform/app/examples/validation/validation-events)
+* [Async Validation Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/dataform/app/examples/validation/async-validation)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/DataForm/Validation/dataform-validation-list.md
+++ b/docs/ui/professional-ui-components/DataForm/Validation/dataform-validation-list.md
@@ -100,9 +100,9 @@ If the provided list doesn't fulfil your requirements, you can define your own v
 
 ## References
 Want to see this scenario in action?
-Check our [SDK Examples](https://github.com/telerik/nativescript-ui-samples) repo on GitHub. You will find many practical examples with NativeScript UI.
+Check our [SDK Examples](https://github.com/NativeScript/nativescript-ui-samples) repo on GitHub. You will find many practical examples with NativeScript UI.
 
-* [Validation Example](https://github.com/telerik/nativescript-ui-samples/tree/master/dataform/app/examples/validation)
+* [Validation Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/dataform/app/examples/validation)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/DataForm/Validation/dataform-validation-modes.md
+++ b/docs/ui/professional-ui-components/DataForm/Validation/dataform-validation-modes.md
@@ -45,9 +45,9 @@ Another option for manual validation is to call the {% typedoc_link classes:RadD
 ## References
 
 Want to see this scenario in action?
-Check our [SDK Examples](https://github.com/telerik/nativescript-ui-samples) repo on GitHub. You will find this and many other practical examples with NativeScript UI.
+Check our [SDK Examples](https://github.com/NativeScript/nativescript-ui-samples) repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Validation Modes Example](https://github.com/telerik/nativescript-ui-samples/tree/master/dataform/app/examples/validation/validation-modes)
+* [Validation Modes Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/dataform/app/examples/validation/validation-modes)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/DataForm/Validation/dataform-validation-overview.md
+++ b/docs/ui/professional-ui-components/DataForm/Validation/dataform-validation-overview.md
@@ -102,10 +102,10 @@ If the existing validators don't provide the required validation, you can create
 ## References
 
 Want to see these scenarios in action?
-Check our [SDK Examples](https://github.com/telerik/nativescript-ui-samples) repo on GitHub. You will find these and many other practical examples with NativeScript UI.
+Check our [SDK Examples](https://github.com/NativeScript/nativescript-ui-samples) repo on GitHub. You will find these and many other practical examples with NativeScript UI.
 
-* [Validation Example](https://github.com/telerik/nativescript-ui-samples/tree/master/dataform/app/examples/validation)
-* [Validators JSON Example](https://github.com/telerik/nativescript-ui-samples/tree/master/dataform/app/examples/validation/metadata)
+* [Validation Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/dataform/app/examples/validation)
+* [Validators JSON Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/dataform/app/examples/validation/metadata)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/DataForm/dataform-imagelabels.md
+++ b/docs/ui/professional-ui-components/DataForm/dataform-imagelabels.md
@@ -30,9 +30,9 @@ By default {% typedoc_link classes:RadDataForm %} will load a label for each edi
 ## References
 
 Want to see this scenario in action?
-Check our [SDK Examples](https://github.com/telerik/nativescript-ui-samples) repository on GitHub. You will find this and many other practical examples with NativeScript UI.
+Check our [SDK Examples](https://github.com/NativeScript/nativescript-ui-samples) repository on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Image Labels Example](https://github.com/telerik/nativescript-ui-samples/tree/master/dataform/app/examples/image-labels)
+* [Image Labels Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/dataform/app/examples/image-labels)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/DataForm/dataform-readonly.md
+++ b/docs/ui/professional-ui-components/DataForm/dataform-readonly.md
@@ -38,10 +38,10 @@ If you need to disable only a specific editor, you can use {% typedoc_link class
 
 ## References
 Want to see these scenarios in action?
-Check our [SDK Examples](https://github.com/telerik/nativescript-ui-samples) repository on GitHub. You will find these and many other practical examples with NativeScript UI.
+Check our [SDK Examples](https://github.com/NativeScript/nativescript-ui-samples) repository on GitHub. You will find these and many other practical examples with NativeScript UI.
 
-* [ReadOnly Example](https://github.com/telerik/nativescript-ui-samples/tree/master/dataform/app/examples/editors/readonly)
-* [Editors Common Example](https://github.com/telerik/nativescript-ui-samples/tree/master/dataform/app/examples/editors)
+* [ReadOnly Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/dataform/app/examples/editors/readonly)
+* [Editors Common Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/dataform/app/examples/editors)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/DataForm/dataform-styling.md
+++ b/docs/ui/professional-ui-components/DataForm/dataform-styling.md
@@ -250,12 +250,12 @@ This is achieved again by using the `editorUpdate` event in `RadDataForm` and th
 ## References
 
 Want to see these scenarios in action?
-Check our [SDK Examples](https://github.com/telerik/nativescript-ui-samples) repo on GitHub. You will find these and many other practical examples with NativeScript UI.
+Check our [SDK Examples](https://github.com/NativeScript/nativescript-ui-samples) repo on GitHub. You will find these and many other practical examples with NativeScript UI.
 
-* [Styling Common Example](https://github.com/telerik/nativescript-ui-samples/tree/master/dataform/app/examples/styling)
-* [Styling Advanced Example](https://github.com/telerik/nativescript-ui-samples/tree/master/dataform/app/examples/styling/advanced)
-* [Platform Adjustments Example](https://github.com/telerik/nativescript-ui-samples/tree/master/dataform/app/examples/platform-specifics)
-* [Editor Background Example](https://github.com/telerik/nativescript-ui-samples/tree/master/dataform/app/examples/styling/editor-background)
+* [Styling Common Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/dataform/app/examples/styling)
+* [Styling Advanced Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/dataform/app/examples/styling/advanced)
+* [Platform Adjustments Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/dataform/app/examples/platform-specifics)
+* [Editor Background Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/dataform/app/examples/styling/editor-background)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/Gauge/getting-started.md
+++ b/docs/ui/professional-ui-components/Gauge/getting-started.md
@@ -44,7 +44,7 @@ To display data the {% typedoc_link classes:RadRadialGauge %} instance is not en
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Getting Started Example](https://github.com/telerik/nativescript-ui-samples/tree/master/gauge/app/examples/getting-started)
+* [Getting Started Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/gauge/app/examples/getting-started)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/Gauge/indicators.md
+++ b/docs/ui/professional-ui-components/Gauge/indicators.md
@@ -52,7 +52,7 @@ The example looks like this:
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Indicators Example](https://github.com/telerik/nativescript-ui-samples/tree/master/gauge/app/examples/scales)
+* [Indicators Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/gauge/app/examples/scales)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/Gauge/scales.md
+++ b/docs/ui/professional-ui-components/Gauge/scales.md
@@ -40,7 +40,7 @@ Now the scales are setup and we should add some indicators. We are going to add 
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Scales Example](https://github.com/telerik/nativescript-ui-samples/tree/master/gauge/app/examples/scales)
+* [Scales Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/gauge/app/examples/scales)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/ListView/data-operations.md
+++ b/docs/ui/professional-ui-components/ListView/data-operations.md
@@ -50,7 +50,7 @@ This will produce the following UI with the filtered, sorted and grouped objects
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Multiple Data Operations Example](https://github.com/telerik/nativescript-ui-samples/tree/master/listview/app/examples/multiple-data-operations)
+* [Multiple Data Operations Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/listview/app/examples/multiple-data-operations)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/ListView/getting-started.md
+++ b/docs/ui/professional-ui-components/ListView/getting-started.md
@@ -56,7 +56,7 @@ Building and running the application will produce the following result:
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Getting Started Example](https://github.com/telerik/nativescript-ui-samples/tree/master/listview/app/examples/getting-started)
+* [Getting Started Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/listview/app/examples/getting-started)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/ListView/header-footer.md
+++ b/docs/ui/professional-ui-components/ListView/header-footer.md
@@ -34,4 +34,4 @@ Here's how the list looks like:
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Header & Footer Example](https://github.com/telerik/nativescript-ui-samples/tree/master/listview/app/examples/header-footer)
+* [Header & Footer Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/listview/app/examples/header-footer)

--- a/docs/ui/professional-ui-components/ListView/item-animations.md
+++ b/docs/ui/professional-ui-components/ListView/item-animations.md
@@ -29,4 +29,4 @@ The currently available item animation types are defined by the {% typedoc_link 
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Item Animations Example](https://github.com/telerik/nativescript-ui-samples/tree/master/listview/app/examples/item-animations)
+* [Item Animations Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/listview/app/examples/item-animations)

--- a/docs/ui/professional-ui-components/ListView/item-layouts.md
+++ b/docs/ui/professional-ui-components/ListView/item-layouts.md
@@ -55,5 +55,5 @@ Defining an explicit item size here is not needed since the essence of a stagger
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Item Layouts Example](https://github.com/telerik/nativescript-ui-samples/tree/master/listview/app/examples/item-layouts)
+* [Item Layouts Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/listview/app/examples/item-layouts)
 

--- a/docs/ui/professional-ui-components/ListView/item-reorder.md
+++ b/docs/ui/professional-ui-components/ListView/item-reorder.md
@@ -64,5 +64,5 @@ The following code snippet demonstrates and example of a {% typedoc_link classes
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Item Reorder Example](https://github.com/telerik/nativescript-ui-samples/tree/master/listview/app/examples/item-reorder)
+* [Item Reorder Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/listview/app/examples/item-reorder)
 

--- a/docs/ui/professional-ui-components/ListView/load-on-demand.md
+++ b/docs/ui/professional-ui-components/ListView/load-on-demand.md
@@ -44,7 +44,7 @@ The {% typedoc_link classes:RadListView,member:loadOnDemandItemTemplate %} prope
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Load On Demand Example](https://github.com/telerik/nativescript-ui-samples/tree/master/listview/app/examples/load-on-demand)
+* [Load On Demand Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/listview/app/examples/load-on-demand)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/ListView/multiple-templates.md
+++ b/docs/ui/professional-ui-components/ListView/multiple-templates.md
@@ -31,5 +31,5 @@ In the code snippets bellow we are declaring multiple `<template></template>` in
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Multiple Item Templates Example](https://github.com/telerik/nativescript-ui-samples/tree/master/listview/app/examples/multiple-templates)
+* [Multiple Item Templates Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/listview/app/examples/multiple-templates)
 

--- a/docs/ui/professional-ui-components/ListView/pull-to-refresh.md
+++ b/docs/ui/professional-ui-components/ListView/pull-to-refresh.md
@@ -39,7 +39,7 @@ Here's a XML sample of how you can customize the indicator in your XML definitio
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Pull To Refresh Example](https://github.com/telerik/nativescript-ui-samples/tree/master/listview/app/examples/pull-to-refresh)
+* [Pull To Refresh Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/listview/app/examples/pull-to-refresh)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/ListView/scrolling.md
+++ b/docs/ui/professional-ui-components/ListView/scrolling.md
@@ -28,4 +28,4 @@ All scrolling events provide an instance of the {% typedoc_link classes:ListView
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Scrolling Example](https://github.com/telerik/nativescript-ui-samples/tree/master/listview/app/examples/scroll-events)
+* [Scrolling Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/listview/app/examples/scroll-events)

--- a/docs/ui/professional-ui-components/ListView/selection.md
+++ b/docs/ui/professional-ui-components/ListView/selection.md
@@ -44,4 +44,4 @@ To notify you when the selection state of an item is changed, {% typedoc_link cl
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Selection Example](https://github.com/telerik/nativescript-ui-samples/tree/master/listview/app/examples/listview-selection)
+* [Selection Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/listview/app/examples/listview-selection)

--- a/docs/ui/professional-ui-components/ListView/swipe-actions.md
+++ b/docs/ui/professional-ui-components/ListView/swipe-actions.md
@@ -129,4 +129,4 @@ Here are two screenshots demonstrating the behavior on Android and iOS:
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Swipe Actions Example](https://github.com/telerik/nativescript-ui-samples/tree/master/listview/app/examples/swipe-actions)
+* [Swipe Actions Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/listview/app/examples/swipe-actions)

--- a/docs/ui/professional-ui-components/SideDrawer/callbacks.md
+++ b/docs/ui/professional-ui-components/SideDrawer/callbacks.md
@@ -25,5 +25,5 @@ You can subscribe for {% typedoc_link classes:RadSideDrawer %}'s events in the c
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Callbacks Example](https://github.com/telerik/nativescript-ui-samples/tree/master/sidedrawer/app/examples/callbacks)
+* [Callbacks Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/sidedrawer/app/examples/callbacks)
 

--- a/docs/ui/professional-ui-components/SideDrawer/getting-started.md
+++ b/docs/ui/professional-ui-components/SideDrawer/getting-started.md
@@ -58,7 +58,7 @@ The following screenshots demonstrate how the drawer looks like in that case:
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [RadAutoCompleteTextView Examples](https://github.com/telerik/nativescript-ui-samples/tree/master/sidedrawer/app/examples/)
+* [RadAutoCompleteTextView Examples](https://github.com/NativeScript/nativescript-ui-samples/tree/master/sidedrawer/app/examples/)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/SideDrawer/locations.md
+++ b/docs/ui/professional-ui-components/SideDrawer/locations.md
@@ -24,4 +24,4 @@ Changing the drawer location is done by setting one of the four possible values 
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Location Example](https://github.com/telerik/nativescript-ui-samples/tree/master/sidedrawer/app/examples/position)
+* [Location Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/sidedrawer/app/examples/position)

--- a/docs/ui/professional-ui-components/SideDrawer/programmatic.md
+++ b/docs/ui/professional-ui-components/SideDrawer/programmatic.md
@@ -21,7 +21,7 @@ Using the {% typedoc_link classes:RadSideDrawer,member:gesturesEnabled %} proper
 Want to see more examples using **RadSideDrawer**?
 Check our SDK examples repository on GitHub. You will find this and a lot more practical examples with NativeScript UI.
 
-* [RadSideDrawer Examples](https://github.com/telerik/nativescript-ui-samples/tree/master/sidedrawer/app/examples)
+* [RadSideDrawer Examples](https://github.com/NativeScript/nativescript-ui-samples/tree/master/sidedrawer/app/examples)
 
 Related articles you mind find useful:
 

--- a/docs/ui/professional-ui-components/SideDrawer/transitions.md
+++ b/docs/ui/professional-ui-components/SideDrawer/transitions.md
@@ -28,4 +28,4 @@ To use a specific transition, you need to set an instance of it to the {% typedo
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Transitions Example](https://github.com/telerik/nativescript-ui-samples/tree/master/sidedrawer/app/examples/transitions)
+* [Transitions Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/sidedrawer/app/examples/transitions)

--- a/docs/ui/professional-ui-components/ng-AutoCompleteTextView/aync-data.md
+++ b/docs/ui/professional-ui-components/ng-AutoCompleteTextView/aync-data.md
@@ -40,5 +40,5 @@ it will use the returned items to complete it's population functionality.
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Remote Data Fetch Example](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/autocomplete/app/examples/remote-data-fetch)
+* [Remote Data Fetch Example](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/autocomplete/app/examples/remote-data-fetch)
 

--- a/docs/ui/professional-ui-components/ng-AutoCompleteTextView/completion-modes.md
+++ b/docs/ui/professional-ui-components/ng-AutoCompleteTextView/completion-modes.md
@@ -35,7 +35,7 @@ Since these suggest modes append the rest of the suggestion to the typed text, t
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [RadAutoCompleteTextView Examples](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/autocomplete/app/examples/)
+* [RadAutoCompleteTextView Examples](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/autocomplete/app/examples/)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/ng-AutoCompleteTextView/display-modes.md
+++ b/docs/ui/professional-ui-components/ng-AutoCompleteTextView/display-modes.md
@@ -48,7 +48,7 @@ In horizontal mode tokens are displayed on single line which can be scrolled hor
 Want to see more examples using **RadAutoCompleteTextView**?
 Check our SDK examples repository on GitHub. You will find this and a lot more practical examples with NativeScript UI.
 
-* [RadAutoCompleteTextView Examples](https://github.com/telerik/nativescript-ui-samples/tree/master/autocomplete/app/)
+* [RadAutoCompleteTextView Examples](https://github.com/NativeScript/nativescript-ui-samples/tree/master/autocomplete/app/)
 
 Related articles you mind find useful:
 

--- a/docs/ui/professional-ui-components/ng-AutoCompleteTextView/events.md
+++ b/docs/ui/professional-ui-components/ng-AutoCompleteTextView/events.md
@@ -36,4 +36,4 @@ In order to get notified when one of the above-mentioned events occur, you shoul
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Events Examples](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/autocomplete/app/examples/events)
+* [Events Examples](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/autocomplete/app/examples/events)

--- a/docs/ui/professional-ui-components/ng-AutoCompleteTextView/getting-started.md
+++ b/docs/ui/professional-ui-components/ng-AutoCompleteTextView/getting-started.md
@@ -39,5 +39,5 @@ The `text` property allows you to change the autocomplete text or get the curren
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [RadAutoCompleteTextView Examples](https://github.com/telerik/nativescript-ui-samples/tree/master/autocomplete/app/examples/getting-started)
+* [RadAutoCompleteTextView Examples](https://github.com/NativeScript/nativescript-ui-samples/tree/master/autocomplete/app/examples/getting-started)
 

--- a/docs/ui/professional-ui-components/ng-AutoCompleteTextView/suggest-modes.md
+++ b/docs/ui/professional-ui-components/ng-AutoCompleteTextView/suggest-modes.md
@@ -37,7 +37,7 @@ In `SuggestAppend` mode the autocomplete combines both upper-mentioned modes. It
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [RadAutoCompleteTextView Examples](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/autocomplete/app/examples/)
+* [RadAutoCompleteTextView Examples](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/autocomplete/app/examples/)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/ng-Calendar/localization.md
+++ b/docs/ui/professional-ui-components/ng-Calendar/localization.md
@@ -24,4 +24,4 @@ The following two screenshots demonstrate how {% typedoc_link classes:RadCalenda
 Want to see this scenario in action?
 Check our Angular SDK examples repository on GitHub. You will find this and a lot more practical examples with NativeScript UI for Angular:
 
-* [RadCalendar Localization Example](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/calendar/app/calendar/calendar-localization)
+* [RadCalendar Localization Example](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/calendar/app/calendar/calendar-localization)

--- a/docs/ui/professional-ui-components/ng-Chart/Axes/datetimecontinuous.md
+++ b/docs/ui/professional-ui-components/ng-Chart/Axes/datetimecontinuous.md
@@ -19,7 +19,7 @@ When [RadCartesianChart]({% slug chart-types-cartesian-angular %} "Read more abo
 > When binding the chart to data that contains Date objects, developers need to convert these date objects to time in **milliseconds**. 
 
 This is necessary because the Telerik UI library calls JSON.stringify() on the data objects before they are passed to the underlying native implementation. Then, the native implementation
-parses back the string to a native Android or iOS object. This call to stringify may produce incorrect results when called on a Date object. To be safe, convert the Date data beforehand to time in milliseconds. For more details take a look at our "Date time axis" example from our sdk repository [here](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/chart/app/examples/axes/date-time-axes)
+parses back the string to a native Android or iOS object. This call to stringify may produce incorrect results when called on a Date object. To be safe, convert the Date data beforehand to time in milliseconds. For more details take a look at our "Date time axis" example from our sdk repository [here](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/chart/app/examples/axes/date-time-axes)
 
 ## Features
 
@@ -51,4 +51,4 @@ You can get and set the current value with the {% typedoc_link classes:Categoric
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [DateTime Continuous Axis Examples](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/chart/app/examples/axes/date-time-axes)
+* [DateTime Continuous Axis Examples](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/chart/app/examples/axes/date-time-axes)

--- a/docs/ui/professional-ui-components/ng-Chart/Behaviors/trackball.md
+++ b/docs/ui/professional-ui-components/ng-Chart/Behaviors/trackball.md
@@ -42,4 +42,4 @@ You can customize the content within the trackball by using the {% typedoc_link 
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Trackball Example](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/chart/app/examples/behaviors)
+* [Trackball Example](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/chart/app/examples/behaviors)

--- a/docs/ui/professional-ui-components/ng-Chart/Legend/legend.md
+++ b/docs/ui/professional-ui-components/ng-Chart/Legend/legend.md
@@ -39,4 +39,4 @@ The following images demonstrate how this setup looks like in a running applicat
 Want to see this scenario in action?
 Check our Angular SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Legend Examples](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/chart/app/examples/legend)
+* [Legend Examples](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/chart/app/examples/legend)

--- a/docs/ui/professional-ui-components/ng-DataForm/Editors/dataform-editors-custom.md
+++ b/docs/ui/professional-ui-components/ng-DataForm/Editors/dataform-editors-custom.md
@@ -61,9 +61,9 @@ We have also created a helper class `ButtonEditorHelper` with an `updateEditorVa
 ## References
 
 Want to see this scenario in action?
-Check our [SDK examples for Angular](https://github.com/telerik/nativescript-ui-samples-angular) repo on GitHub. You will find this and many other practical examples with NativeScript UI.
+Check our [SDK examples for Angular](https://github.com/NativeScript/nativescript-ui-samples-angular) repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Custom Editors Example](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/dataform/app/examples/editors/custom-editors)
+* [Custom Editors Example](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/dataform/app/examples/editors/custom-editors)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/ng-DataForm/Editors/dataform-editors-list.md
+++ b/docs/ui/professional-ui-components/ng-DataForm/Editors/dataform-editors-list.md
@@ -225,11 +225,11 @@ If an editor that you would like to use is not included in the list with predefi
 ## References
 
 Want to see this scenario in action?
-Check our [SDK Examples for Angular](https://github.com/telerik/nativescript-ui-samples-angular) repo on GitHub. You will find theis and many other practical examples with NativeScript UI.
+Check our [SDK Examples for Angular](https://github.com/NativeScript/nativescript-ui-samples-angular) repo on GitHub. You will find theis and many other practical examples with NativeScript UI.
 
-* [Editors Common Example](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/dataform/app/examples/editors)
-* [Editors AutoComplete Example](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/dataform/app/examples/editors/autocomplete)
-* [Editors Labels Example](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/dataform/app/examples/editors/labels)
+* [Editors Common Example](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/dataform/app/examples/editors)
+* [Editors AutoComplete Example](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/dataform/app/examples/editors/autocomplete)
+* [Editors Labels Example](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/dataform/app/examples/editors/labels)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/ng-DataForm/Editors/dataform-editors-overview.md
+++ b/docs/ui/professional-ui-components/ng-DataForm/Editors/dataform-editors-overview.md
@@ -61,10 +61,10 @@ You can find the list with all available editors [here]({% slug dataform-editors
 ## References
 
 Want to see these scenarios in action?
-Check our [SDK Examples for Angular](https://github.com/telerik/nativescript-ui-samples-angular) repo on GitHub. You will find these and many other practical examples with NativeScript UI.
+Check our [SDK Examples for Angular](https://github.com/NativeScript/nativescript-ui-samples-angular) repo on GitHub. You will find these and many other practical examples with NativeScript UI.
 
-* [Editors Common Example](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/dataform/app/examples/editors)
-* [Runtime Updates Example](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/dataform/app/examples/runtime-updates)
+* [Editors Common Example](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/dataform/app/examples/editors)
+* [Runtime Updates Example](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/dataform/app/examples/runtime-updates)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/ng-DataForm/Editors/dataform-editors-providers.md
+++ b/docs/ui/professional-ui-components/ng-DataForm/Editors/dataform-editors-providers.md
@@ -69,10 +69,10 @@ If you want to use an `Array` with your custom objects and they don't have `key`
 ## References
 
 Want to see these scenarios in action?
-Check our [SDK Examples for Angular](https://github.com/telerik/nativescript-ui-samples-angular) repo on GitHub. You will find these and many other practical examples with NativeScript UI.
+Check our [SDK Examples for Angular](https://github.com/NativeScript/nativescript-ui-samples-angular) repo on GitHub. You will find these and many other practical examples with NativeScript UI.
 
-* [Value Providers Example](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/dataform/app/examples/value-providers)
-* [Editors Common Example](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/dataform/app/examples/editors)
+* [Value Providers Example](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/dataform/app/examples/value-providers)
+* [Editors Common Example](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/dataform/app/examples/editors)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/ng-DataForm/GettingStarted/dataform-start-properties.md
+++ b/docs/ui/professional-ui-components/ng-DataForm/GettingStarted/dataform-start-properties.md
@@ -145,11 +145,11 @@ Our next step is to determine the values of the source object reflecting the cha
 ## References
 
 Want to see these scenarios in action?
-Check our [SDK Examples for Angular](https://github.com/telerik/nativescript-ui-samples-angular) repo on GitHub. You will find these and many other practical examples with NativeScript UI.
+Check our [SDK Examples for Angular](https://github.com/NativeScript/nativescript-ui-samples-angular) repo on GitHub. You will find these and many other practical examples with NativeScript UI.
 
-* [Properties Example](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/dataform/app/examples/adjustment)
-* [Runtime Updates Example](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/dataform/app/examples/runtime-updates)
-* [Properties JSON Example](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/dataform/app/examples/properties-json)
+* [Properties Example](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/dataform/app/examples/adjustment)
+* [Runtime Updates Example](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/dataform/app/examples/runtime-updates)
+* [Properties JSON Example](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/dataform/app/examples/properties-json)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/ng-DataForm/GettingStarted/dataform-start-result.md
+++ b/docs/ui/professional-ui-components/ng-DataForm/GettingStarted/dataform-start-result.md
@@ -47,11 +47,11 @@ The other event - **propertyCommitted** - is called after the property is commit
 ## References
 
 Want to see these scenarios in action?
-Check our [SDK Examples for Angular](https://github.com/telerik/nativescript-ui-samples-angular) repo on GitHub. You will find these and many other practical examples with NativeScript UI.
+Check our [SDK Examples for Angular](https://github.com/NativeScript/nativescript-ui-samples-angular) repo on GitHub. You will find these and many other practical examples with NativeScript UI.
 
-* [Commit Modes Example](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/dataform/app/examples/commit-modes)
-* [Events Example](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/dataform/app/examples/events)
-* [Scrollable Form Example](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/dataform/app/examples/scrolling)
+* [Commit Modes Example](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/dataform/app/examples/commit-modes)
+* [Events Example](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/dataform/app/examples/events)
+* [Scrollable Form Example](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/dataform/app/examples/scrolling)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/ng-DataForm/GettingStarted/dataform-start-source.md
+++ b/docs/ui/professional-ui-components/ng-DataForm/GettingStarted/dataform-start-source.md
@@ -58,10 +58,10 @@ Our next step is to adjust the editors that are used for each of the source obje
 ## References
 
 Want to see these scenarios in action?
-Check our [SDK Examples for Angular](https://github.com/telerik/nativescript-ui-samples-angular) repo on GitHub. You will find these and many other practical examples with NativeScript UI.
+Check our [SDK Examples for Angular](https://github.com/NativeScript/nativescript-ui-samples-angular) repo on GitHub. You will find these and many other practical examples with NativeScript UI.
 
-* [Getting Started Example](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/dataform/app/examples/getting-started)
-* [Getting Started JSON Example](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/dataform/app/examples/getting-started-json)
+* [Getting Started Example](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/dataform/app/examples/getting-started)
+* [Getting Started JSON Example](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/dataform/app/examples/getting-started-json)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/ng-DataForm/Groups/dataform-groups-layouts.md
+++ b/docs/ui/professional-ui-components/ng-DataForm/Groups/dataform-groups-layouts.md
@@ -54,9 +54,9 @@ First we need to declare the `RadDataForm` and each of its `TKPropertyGroup` as 
 ## References
 
 Want to see this scenario in action?
-Check our [SDK Examples for Angular](https://github.com/telerik/nativescript-ui-samples-angular) repo on GitHub. You will find this and many other practical examples with NativeScript UI.
+Check our [SDK Examples for Angular](https://github.com/NativeScript/nativescript-ui-samples-angular) repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Layouts Example](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/dataform/app/examples/layouts)
+* [Layouts Example](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/dataform/app/examples/layouts)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/ng-DataForm/Groups/dataform-groups-overview.md
+++ b/docs/ui/professional-ui-components/ng-DataForm/Groups/dataform-groups-overview.md
@@ -123,10 +123,10 @@ public onGroupUpdate(args) {
 ## References
 
 Want to see these scenarios in action?
-Check our [SDK Examples for Angular](https://github.com/telerik/nativescript-ui-samples-angular) repo on GitHub. You will find this and many other practical examples with NativeScript UI.
+Check our [SDK Examples for Angular](https://github.com/NativeScript/nativescript-ui-samples-angular) repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Groups Example](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/dataform/app/examples/groups)
-* [Runtime Updates Example](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/dataform/app/examples/runtime-updates)
+* [Groups Example](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/dataform/app/examples/groups)
+* [Runtime Updates Example](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/dataform/app/examples/runtime-updates)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/ng-DataForm/Validation/dataform-validation-custom.md
+++ b/docs/ui/professional-ui-components/ng-DataForm/Validation/dataform-validation-custom.md
@@ -57,10 +57,10 @@ Let's walk through that implementation. First, we are getting each `EntityProper
 ## References
 
 Want to see this scenario in action?
-Check our [SDK examples for Angular](https://github.com/telerik/nativescript-ui-samples-angular) repo on GitHub. You will find these and many other practical examples with NativeScript UI.
+Check our [SDK examples for Angular](https://github.com/NativeScript/nativescript-ui-samples-angular) repo on GitHub. You will find these and many other practical examples with NativeScript UI.
 
-* [Custom Validator Example](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/dataform/app/examples/validation/custom-validator)
-* [Custom Validation Example](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/dataform/app/examples/validation/custom-validation)
+* [Custom Validator Example](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/dataform/app/examples/validation/custom-validator)
+* [Custom Validation Example](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/dataform/app/examples/validation/custom-validation)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/ng-DataForm/Validation/dataform-validation-events.md
+++ b/docs/ui/professional-ui-components/ng-DataForm/Validation/dataform-validation-events.md
@@ -63,10 +63,10 @@ The **propertyValidated** event gives you an opportunity to get notified that a 
 ## References
 
 Want to see these scenarios in action?
-Check our [SDK examples for Angular](https://github.com/telerik/nativescript-ui-samples-angular) repo on GitHub. You will find these and many other practical examples with NativeScript UI.
+Check our [SDK examples for Angular](https://github.com/NativeScript/nativescript-ui-samples-angular) repo on GitHub. You will find these and many other practical examples with NativeScript UI.
 
-* [Validation Events Example](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/dataform/app/examples/validation/validation-events)
-* [Async Validation Example](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/dataform/app/examples/validation/async-validation)
+* [Validation Events Example](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/dataform/app/examples/validation/validation-events)
+* [Async Validation Example](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/dataform/app/examples/validation/async-validation)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/ng-DataForm/Validation/dataform-validation-list.md
+++ b/docs/ui/professional-ui-components/ng-DataForm/Validation/dataform-validation-list.md
@@ -101,9 +101,9 @@ If the provided list doesn't fulfil your requirements, you can define your own v
 ## References
 
 Want to see this scenario in action?
-Check our [SDK examples for Angular](https://github.com/telerik/nativescript-ui-samples-angular) repo on GitHub. You will find many practical examples with NativeScript UI.
+Check our [SDK examples for Angular](https://github.com/NativeScript/nativescript-ui-samples-angular) repo on GitHub. You will find many practical examples with NativeScript UI.
 
-* [Validation Example](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/dataform/app/examples/validation)
+* [Validation Example](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/dataform/app/examples/validation)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/ng-DataForm/Validation/dataform-validation-modes.md
+++ b/docs/ui/professional-ui-components/ng-DataForm/Validation/dataform-validation-modes.md
@@ -46,9 +46,9 @@ Another option for manual validation is to call the {% typedoc_link classes:RadD
 ## References
 
 Want to see this scenario in action?
-Check our [SDK examples for Angular](https://github.com/telerik/nativescript-ui-samples-angular) repo on GitHub. You will find this and many other practical examples with NativeScript UI.
+Check our [SDK examples for Angular](https://github.com/NativeScript/nativescript-ui-samples-angular) repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Validation Modes Example](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/dataform/app/examples/validation/validation-modes)
+* [Validation Modes Example](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/dataform/app/examples/validation/validation-modes)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/ng-DataForm/Validation/dataform-validation-overview.md
+++ b/docs/ui/professional-ui-components/ng-DataForm/Validation/dataform-validation-overview.md
@@ -102,10 +102,10 @@ If the existing validators don't provide the required validation, you can create
 ## References
 
 Want to see these scenarios in action?
-Check our [SDK examples for Angular](https://github.com/telerik/nativescript-ui-samples-angular) repo on GitHub. You will find these and many other practical examples with NativeScript UI.
+Check our [SDK examples for Angular](https://github.com/NativeScript/nativescript-ui-samples-angular) repo on GitHub. You will find these and many other practical examples with NativeScript UI.
 
-* [Validation Example](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/dataform/app/examples/validation)
-* [Validators JSON Example](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/dataform/app/examples/validation/metadata)
+* [Validation Example](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/dataform/app/examples/validation)
+* [Validators JSON Example](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/dataform/app/examples/validation/metadata)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/ng-DataForm/dataform-imagelabels.md
+++ b/docs/ui/professional-ui-components/ng-DataForm/dataform-imagelabels.md
@@ -30,9 +30,9 @@ By default {% typedoc_link classes:RadDataForm %} will load a label for each edi
 ## References
 
 Want to see this scenario in action?
-Check our [SDK Examples for Angular](https://github.com/telerik/nativescript-ui-samples-angular) repository on GitHub. You will find this and a lot more practical examples with NativeScript UI.
+Check our [SDK Examples for Angular](https://github.com/NativeScript/nativescript-ui-samples-angular) repository on GitHub. You will find this and a lot more practical examples with NativeScript UI.
 
-* [Image Labels Example](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/dataform/app/examples/image-labels)
+* [Image Labels Example](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/dataform/app/examples/image-labels)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/ng-DataForm/dataform-readonly.md
+++ b/docs/ui/professional-ui-components/ng-DataForm/dataform-readonly.md
@@ -39,10 +39,10 @@ If you need to disable only a specific editor, you can use {% typedoc_link class
 ## References
 
 Want to see these scenarios in action?
-Check our [SDK Examples for Angular](https://github.com/telerik/nativescript-ui-samples-angular) repository on GitHub. You will find these and many other practical examples with NativeScript UI.
+Check our [SDK Examples for Angular](https://github.com/NativeScript/nativescript-ui-samples-angular) repository on GitHub. You will find these and many other practical examples with NativeScript UI.
 
-* [ReadOnly Example](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/dataform/app/examples/editors/readonly)
-* [Editors Common Example](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/dataform/app/examples/editors)
+* [ReadOnly Example](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/dataform/app/examples/editors/readonly)
+* [Editors Common Example](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/dataform/app/examples/editors)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/ng-DataForm/dataform-styling.md
+++ b/docs/ui/professional-ui-components/ng-DataForm/dataform-styling.md
@@ -253,12 +253,12 @@ This is achieved again by using the `editorUpdate` event in `RadDataForm` and th
 ## References
 
 Want to see these scenarios in action?
-Check our [SDK examples for Angular](https://github.com/telerik/nativescript-ui-samples-angular) repo on GitHub. You will find these and many other practical examples with NativeScript UI.
+Check our [SDK examples for Angular](https://github.com/NativeScript/nativescript-ui-samples-angular) repo on GitHub. You will find these and many other practical examples with NativeScript UI.
 
-* [Styling Common Example](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/dataform/app/examples/styling)
-* [Styling Advanced Example](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/dataform/app/examples/styling/advanced)
-* [Platform Adjustments Example](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/dataform/app/examples/platform-specifics)
-* [Editor Background Example](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/dataform/app/examples/styling/editor-background)
+* [Styling Common Example](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/dataform/app/examples/styling)
+* [Styling Advanced Example](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/dataform/app/examples/styling/advanced)
+* [Platform Adjustments Example](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/dataform/app/examples/platform-specifics)
+* [Editor Background Example](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/dataform/app/examples/styling/editor-background)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/ng-Gauge/getting-started.md
+++ b/docs/ui/professional-ui-components/ng-Gauge/getting-started.md
@@ -39,7 +39,7 @@ In order to setup an `RadRadialGauge` in your Component HTML you will need to fo
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Getting Started Example](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/gauge/app/examples/getting-started)
+* [Getting Started Example](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/gauge/app/examples/getting-started)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/ng-Gauge/indicators.md
+++ b/docs/ui/professional-ui-components/ng-Gauge/indicators.md
@@ -56,7 +56,7 @@ The example looks like this:
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Indicators Example](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/gauge/app/examples/scales)
+* [Indicators Example](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/gauge/app/examples/scales)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/ng-Gauge/scales.md
+++ b/docs/ui/professional-ui-components/ng-Gauge/scales.md
@@ -40,7 +40,7 @@ This is what you should see when you run the app:
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Scales Example](https://github.com/telerik/nativescript-ui-samples/tree/master/gauge/app/examples/scales)
+* [Scales Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/gauge/app/examples/scales)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/ng-ListView/data-operations.md
+++ b/docs/ui/professional-ui-components/ng-ListView/data-operations.md
@@ -51,7 +51,7 @@ This will produce the following UI with the filtered, sorted and grouped objects
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Multiple Data Operations Example](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/listview/app/examples/multiple-operations)
+* [Multiple Data Operations Example](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/listview/app/examples/multiple-operations)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/ng-ListView/getting-started.md
+++ b/docs/ui/professional-ui-components/ng-ListView/getting-started.md
@@ -35,7 +35,7 @@ Following the Angular best practices, we have separated the data from the UI by 
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Getting Started Example](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/listview/app/examples/getting-started)
+* [Getting Started Example](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/listview/app/examples/getting-started)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/ng-ListView/multiple-templates.md
+++ b/docs/ui/professional-ui-components/ng-ListView/multiple-templates.md
@@ -31,5 +31,5 @@ In the code snippets bellow we are declaring multiple `<ng-template></ng-templat
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Multiple Item Templates Example](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/listview/app/examples/multiple-templates)
+* [Multiple Item Templates Example](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/listview/app/examples/multiple-templates)
 

--- a/docs/ui/professional-ui-components/ng-ListView/scrolling.md
+++ b/docs/ui/professional-ui-components/ng-ListView/scrolling.md
@@ -29,4 +29,4 @@ All scrolling events provide an instance of the {% typedoc_link classes:ListView
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Scrolling Example](https://github.com/telerik/nativescript-ui-samples/tree/master/listview/app/examples/scroll-events)
+* [Scrolling Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/listview/app/examples/scroll-events)

--- a/docs/ui/professional-ui-components/ng-SideDrawer/getting-started.md
+++ b/docs/ui/professional-ui-components/ng-SideDrawer/getting-started.md
@@ -61,7 +61,7 @@ The following code snippet is a simple template with a basic setup for RadSideDr
 Want to see this scenario in action?
 Check our SDK examples repository on GitHub. You will find this and a lot more practical examples with NativeScript UI.
 
-* [Getting Started Example](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/sidedrawer/app/examples/getting-started)
+* [Getting Started Example](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/sidedrawer/app/examples/getting-started)
 
 Related articles you might find useful:
 

--- a/docs/ui/professional-ui-components/overview.md
+++ b/docs/ui/professional-ui-components/overview.md
@@ -9,21 +9,21 @@ publish: true
 
 # NativeScript UI Overview
 
-NativeScript UI is a set of free* components that enable implementing rich-ui applications for iOS and Android by using [NativeScript](https://www.nativescript.org). **Progress NativeScript UI** is built on top of natively implemented components targeting iOS and Android. The components are available for download on npmjs.com 
+NativeScript UI is a set of free* components that enable implementing rich-ui applications for iOS and Android by using [NativeScript](https://www.nativescript.org). **Progress NativeScript UI** is built on top of natively implemented components targeting iOS and Android. Each of the components is available for download on npmjs.com as a separate package.
 
-> *Although the components are free, they are not open-source and their code is proprietary. [Read the components' license for details](https://github.com/telerik/nativescript-ui-feedback/blob/master/LICENSE.md). 
+> *Although the components are free, they are not open-source and their code is proprietary. [Read the components' license for details](https://github.com/NativeScript/nativescript-ui-feedback/blob/master/LICENSE.md). 
 
-> In case you're interested in contributing to the code base, [read the contributing options available](https://github.com/telerik/nativescript-ui-feedback#contributing-to-nativescript-ui).
+> In case you're interested in contributing to the code base, [read the contributing options available](https://github.com/NativeScript/nativescript-ui-feedback#contributing-to-nativescript-ui).
 
-Continue reading about each component below or take them for a spin with the {% nativescript %}[NativeScript UI sample app on GitHub](https://github.com/telerik/nativescript-ui-samples){% endnativescript %}{% angular %}[NativeScript UI sample app on GitHub](https://github.com/telerik/nativescript-ui-samples-angular){%  endangular %}.
+Continue reading about each component below or take them for a spin with the {% nativescript %}[NativeScript UI sample app on GitHub](https://github.com/NativeScript/nativescript-ui-samples){% endnativescript %}{% angular %}[NativeScript UI sample app on GitHub](https://github.com/NativeScript/nativescript-ui-samples-angular){%  endangular %}.
 
 ## Components
 
 ### RadSideDrawer
 
-[{% nativescript %}[Documentation]({% slug sidedrawer-overview %}){% endnativescript %}{% angular %}[Documentation]({% slug sidedrawer-overview-angular %}){% endangular %}] [{% nativescript %}[Sample Code](https://github.com/telerik/nativescript-ui-samples/tree/master/sidedrawer){% endnativescript %}{% angular %}[Sample Code](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/sidedrawer){% endangular %}][[Download from npm](https://www.npmjs.com/package/nativescript-ui-sidedrawer)]
+[{% nativescript %}[Documentation]({% slug sidedrawer-overview %}){% endnativescript %}{% angular %}[Documentation]({% slug sidedrawer-overview-angular %}){% endangular %}] [{% nativescript %}[Sample Code](https://github.com/NativeScript/nativescript-ui-samples/tree/master/sidedrawer){% endnativescript %}{% angular %}[Sample Code](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/sidedrawer){% endangular %}][[Download from npm](https://www.npmjs.com/package/nativescript-ui-sidedrawer)]
 
-The SideDrawer component (known as RadSideDrawer in code) allows you to follow a popular application pattern and show a hidden view which contains navigation UI or common settings. With SideDrawer you may:
+The SideDrawer component (known as RadSideDrawer in code and distributed through the `nativescript-ui-sidedrawer` package) allows you to follow a popular application pattern and show a hidden view which contains navigation UI or common settings. With SideDrawer you may:
 
 * Embed any content inside the sliding panel from text and icons, to sliders and filters;
 * Set the control to slide in from any of the four sides of the screen;
@@ -36,11 +36,11 @@ The SideDrawer component (known as RadSideDrawer in code) allows you to follow a
 
 ### RadListView
 
-[{% nativescript %}[Documentation]({% slug listview-overview %}){% endnativescript %}{% angular %}[Documentation]({% slug listview-overview-angular %}){% endangular %}] [{% nativescript %}[Sample Code](https://github.com/telerik/nativescript-ui-samples/tree/master/listview){% endnativescript %}{% angular %}[Sample Code](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/listview){% endangular %}][[Download from npm](https://www.npmjs.com/package/nativescript-ui-listview)]
+[{% nativescript %}[Documentation]({% slug listview-overview %}){% endnativescript %}{% angular %}[Documentation]({% slug listview-overview-angular %}){% endangular %}] [{% nativescript %}[Sample Code](https://github.com/NativeScript/nativescript-ui-samples/tree/master/listview){% endnativescript %}{% angular %}[Sample Code](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/listview){% endangular %}][[Download from npm](https://www.npmjs.com/package/nativescript-ui-listview)]
 
 > **NOTE**: The professional ListView component is different from the ListView built in to the core NativeScript modules. Use the professional ListView if you need to take advantage of the advanced functionality listed below.
 
-The ListView component (known as RadListView in code) is a virtualizing list component that provides the most needed features associated with scenarios where a list of items is used. Features include:
+The ListView component (known as RadListView in code and distributed through the `nativescript-ui-listview` package) is a virtualizing list component that provides the most needed features associated with scenarios where a list of items is used. Features include:
 
 * Pull to refresh;
 * Load on demand;
@@ -55,9 +55,9 @@ The ListView component (known as RadListView in code) is a virtualizing list com
 
 ### RadCalendar
 
-[{% nativescript %}[Documentation]({% slug calendar-overview %}){% endnativescript %}{% angular %}[Documentation]({% slug calendar-overview-angular %}){% endangular %}] [{% nativescript %}[Sample Code](https://github.com/telerik/nativescript-ui-samples/tree/master/calendar){% endnativescript %}{% angular %}[Sample Code](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/calendar){% endangular %}][[Download from npm](https://www.npmjs.com/package/nativescript-ui-calendar)]
+[{% nativescript %}[Documentation]({% slug calendar-overview %}){% endnativescript %}{% angular %}[Documentation]({% slug calendar-overview-angular %}){% endangular %}] [{% nativescript %}[Sample Code](https://github.com/NativeScript/nativescript-ui-samples/tree/master/calendar){% endnativescript %}{% angular %}[Sample Code](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/calendar){% endangular %}][[Download from npm](https://www.npmjs.com/package/nativescript-ui-calendar)]
 
-The Calendar component (known as RadCalendar in code) is a highly customizable native calendar abstraction that exposes a unified API, covering:
+The Calendar component (known as RadCalendar in code and distributed through the `nativescript-ui-calendar` package) is a highly customizable native calendar abstraction that exposes a unified API, covering:
 
 * Four different view modes - `Week`, `Month`, `MonthNames`, and `Year`;
 * `Single`, `Multiple`, and `Range` date selection;
@@ -69,9 +69,9 @@ The Calendar component (known as RadCalendar in code) is a highly customizable n
 
 ### RadChart
 
-[{% nativescript %}[Documentation]({% slug chart-overview %}){% endnativescript %}{% angular %}[Documentation]({% slug chart-overview-angular %}){% endangular %}] [{% nativescript %}[Sample Code](https://github.com/telerik/nativescript-ui-samples/tree/master/chart){% endnativescript %}{% angular %}[Sample Code](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/chart){% endangular %}][[Download from npm](https://www.npmjs.com/package/nativescript-ui-chart)]
+[{% nativescript %}[Documentation]({% slug chart-overview %}){% endnativescript %}{% angular %}[Documentation]({% slug chart-overview-angular %}){% endangular %}] [{% nativescript %}[Sample Code](https://github.com/NativeScript/nativescript-ui-samples/tree/master/chart){% endnativescript %}{% angular %}[Sample Code](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/chart){% endangular %}][[Download from npm](https://www.npmjs.com/package/nativescript-ui-chart)]
 
-The Chart component (known as RadChart in code) can be used to visualize data in a human-readable way through lines, areas, bars, pies, and more. Some features include:
+The Chart component includes two types of charts: cartesian (known as RadCartesianChart in code) and pie (known as RadPieChart in code) and is distributed through the `nativescript-ui-chart` package. It can be used to visualize data in a human-readable way through lines, areas, bars, pies, and more. Some features include:
 
 * Wide array of accepted data types: numerical, string or `DateTime` data depending on the chart you want to visualize;
 * Smooth interaction and zooming;
@@ -89,9 +89,9 @@ The Chart component (known as RadChart in code) can be used to visualize data in
 
 ### RadAutoCompleteTextView
 
-[{% nativescript %}[Documentation]({% slug autocomplete-overview %}){% endnativescript %}{% angular %}[Documentation]({% slug autocomplete-overview-angular %}){% endangular %}] [{% nativescript %}[Sample Code](https://github.com/telerik/nativescript-ui-samples/tree/master/autocomplete){% endnativescript %}{% angular %}[Sample Code](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/autocomplete){% endangular %}][[Download from npm](https://www.npmjs.com/package/nativescript-ui-autocomplete)]
+[{% nativescript %}[Documentation]({% slug autocomplete-overview %}){% endnativescript %}{% angular %}[Documentation]({% slug autocomplete-overview-angular %}){% endangular %}] [{% nativescript %}[Sample Code](https://github.com/NativeScript/nativescript-ui-samples/tree/master/autocomplete){% endnativescript %}{% angular %}[Sample Code](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/autocomplete){% endangular %}][[Download from npm](https://www.npmjs.com/package/nativescript-ui-autocomplete)]
 
-The AutoCompleteTextView component (known as RadAutoCompleteTextView in code) offers suggested options to your users based on characters they type. It provides multiple means for easy customization and data management, including:
+The AutoComplete component (known as RadAutoCompleteTextView in code and distributed through the `nativescript-ui-autocomplete` package) offers suggested options to your users based on characters they type. It provides multiple means for easy customization and data management, including:
 
 *  Suggest modes - you can choose to show suggestions in a drop-down list, one suggestion at a time in the text input, or a combination of both;
 *  `StartsWith` and `Contains` completion modes;
@@ -103,9 +103,9 @@ The AutoCompleteTextView component (known as RadAutoCompleteTextView in code) of
 
 ### RadDataForm
 
-[{% nativescript %}[Documentation]({% slug dataform-overview %}){% endnativescript %}{% angular %}[Documentation]({% slug dataform-overview-angular %}){% endangular %}] [{% nativescript %}[Sample Code](https://github.com/telerik/nativescript-ui-samples/tree/master/dataform){% endnativescript %}{% angular %}[Sample Code](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/dataform){% endangular %}][[Download from npm](https://www.npmjs.com/package/nativescript-ui-dataform)]
+[{% nativescript %}[Documentation]({% slug dataform-overview %}){% endnativescript %}{% angular %}[Documentation]({% slug dataform-overview-angular %}){% endangular %}] [{% nativescript %}[Sample Code](https://github.com/NativeScript/nativescript-ui-samples/tree/master/dataform){% endnativescript %}{% angular %}[Sample Code](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/dataform){% endangular %}][[Download from npm](https://www.npmjs.com/package/nativescript-ui-dataform)]
 
-The DataForm component (known as RadDataForm in code) provides an easy and versatile approach for building mobile forms based on a provided data object's public members. Use DataForm to:
+The DataForm component (known as RadDataForm in code and distributed through the `nativescript-ui-dataform` package) provides an easy and versatile approach for building mobile forms based on a provided data object's public members. Use DataForm to:
 
 * Bind a form to a data object with a single line of code;
 * Take advantage of more than **15** built-in editors (or provide your own custom editor);
@@ -116,11 +116,11 @@ The DataForm component (known as RadDataForm in code) provides an easy and versa
 ![dataform ios](../../img/ui-for-nativescript/dataform-ios.png "dataform ios") ![dataform android](../../img/ui-for-nativescript/dataform-android.png "dataform android")
 
 
-### RadGauges
+### RadGauge
 
-[{% nativescript %}[Documentation]({% slug gauges-overview %}){% endnativescript %}{% angular %}[Documentation]({% slug gauges-overview-angular %}){% endangular %}] [{% nativescript %}[Sample Code](https://github.com/telerik/nativescript-ui-samples/tree/master/gauge){% endnativescript %}{% angular %}[Sample Code](https://github.com/telerik/nativescript-ui-samples-angular/tree/master/gauge){% endangular %}][[Download from npm](https://www.npmjs.com/package/nativescript-ui-gauge)]
+[{% nativescript %}[Documentation]({% slug gauges-overview %}){% endnativescript %}{% angular %}[Documentation]({% slug gauges-overview-angular %}){% endangular %}] [{% nativescript %}[Sample Code](https://github.com/NativeScript/nativescript-ui-samples/tree/master/gauge){% endnativescript %}{% angular %}[Sample Code](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/gauge){% endangular %}][[Download from npm](https://www.npmjs.com/package/nativescript-ui-gauge)]
 
-The Gauges component (known as RadRadialGauge in code) allows you to display the current status of a value within a range of upper and lower bounds, illustrate progress towards a goal, or a summary of a fluctuating metric. With the gauges component you may:
+The Gauge component (known as RadRadialGauge in code and distributed through the `nativescript-ui-gauge` package) allows you to display the current status of a value within a range of upper and lower bounds, illustrate progress towards a goal, or a summary of a fluctuating metric. With the gauges component you may:
 
 * Add one or more `RadialScale` instances to your gauge;
 * Use `Bar` indicators to visualize a range of values or a `Needle` indicator to point to a specific value;
@@ -133,7 +133,7 @@ The Gauges component (known as RadRadialGauge in code) allows you to display the
 
 ### SDK samples app
 
-You can explore the Progress NativeScript UI getting started application, which is [publicly available on GitHub]{% nativescript %}(https://www.github.com/telerik/nativescript-ui-samples){% endnativescript %}{% angular %}(https://www.github.com/telerik/nativescript-ui-samples-angular){% endangular %}. It contains various examples of the usage of the components. More information about how to run the application is available in its README.
+You can explore the Progress NativeScript UI getting started application, which is [publicly available on GitHub]{% nativescript %}(https://www.github.com/NativeScript/nativescript-ui-samples){% endnativescript %}{% angular %}(https://www.github.com/NativeScript/nativescript-ui-samples-angular){% endangular %}. It contains various examples of the usage of the components. More information about how to run the application is available in its README.
 
 ### AppStore/PlayStore sample app
 In case you want to experience the native side of NativeScript and Progress NativeScript UI to the fullest, you can refer to the official sample NativeScript application. Its source code is located in [this GitHub repo](https://github.com/NativeScript/nativescript-marketplace-demo). You can easily check how the app works on your device by getting it from [AppStore](https://itunes.apple.com/us/app/examples-nativescript/id1046772499?ls=1&mt=8) or [PlayStore](https://play.google.com/store/apps/details?id=org.nativescript.examples).
@@ -141,4 +141,4 @@ In case you want to experience the native side of NativeScript and Progress Nati
 ## Feedback
 Your feedback will be highly appreciated and will directly influence the development of **Progress NativeScript UI**.
 
-You can submit issues and feedback to the [dedicated feedback GitHub repository](https://github.com/telerik/nativescript-ui-feedback).
+You can submit issues and feedback to the [dedicated feedback GitHub repository](https://github.com/NativeScript/nativescript-ui-feedback).

--- a/vuejs-docs/ns-ui/Gauge/indicators.md
+++ b/vuejs-docs/ns-ui/Gauge/indicators.md
@@ -56,7 +56,7 @@ The example looks like this:
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Indicators Example](https://github.com/telerik/nativescript-ui-samples-vue/tree/master/gauge/app/examples/scales)
+* [Indicators Example](https://github.com/NativeScript/nativescript-ui-samples-vue/tree/master/gauge/app/examples/scales)
 
 Related articles you might find useful:
 

--- a/vuejs-docs/ns-ui/Gauge/scales.md
+++ b/vuejs-docs/ns-ui/Gauge/scales.md
@@ -39,7 +39,7 @@ This is what you should see when you run the app:
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [Scales Example](https://github.com/telerik/nativescript-ui-samples/tree/master/gauge/app/examples/scales)
+* [Scales Example](https://github.com/NativeScript/nativescript-ui-samples/tree/master/gauge/app/examples/scales)
 
 Related articles you might find useful:
 

--- a/vuejs-docs/ns-ui/overview.md
+++ b/vuejs-docs/ns-ui/overview.md
@@ -22,7 +22,7 @@ If you are comfortable with using vue for your NativeScript development purposes
 - [Gauge]({% slug gauges-gettingstarted-vue %} "Read more about the Gauge plugin")
 
 ## ListView for Vue: overview
-ListView for Vue exposes all of the familiar features already available through the NativeScript UI APIs:
+ListView for Vue (distributed through the `nativescript-ui-listview` package on npmjs) exposes all of the familiar features already available through the NativeScript UI APIs:
 
 - Pull to refresh
 - Swipe to execute
@@ -31,7 +31,7 @@ ListView for Vue exposes all of the familiar features already available through 
 For more information on setting up and using a particular feature, take a look at the dedicated [article]({% slug listview-getting-started-vue %} "Read more about RadListView with Vue.") in RadListView's documentation section. The articles are extended with Vue snippets and explanations where needed.
 
 ## SideDrawer for Vue: overview
-SideDrawer for Vue brings the familiar experience to your Vue based NativeScript application of separating the main menu from home page content via animated views. The following features are supported:
+SideDrawer for Vue (distributed through the `nativescript-ui-sidedrawer` package on npmjs) brings the familiar experience to your Vue based NativeScript application of separating the main menu from home page content via animated views. The following features are supported:
 
 - Transitions
 - Drawer location
@@ -40,7 +40,7 @@ SideDrawer for Vue brings the familiar experience to your Vue based NativeScript
 For more information on setting up and using a particular feature, take a look at the dedicated [article]({% slug sidedrawer-getting-started-vue %} "Read more about RadListView with vue.") in RadSideDrawer's documentation section. The articles are extended with vue snippets and explanations where needed.
 
 ## Calendar for Vue: overview
-Calendar for Vue exposes all of the familiar features already available through the NativeScript UI APIs:
+Calendar for Vue (distributed through the `nativescript-ui-calendar` package on npmjs) exposes all of the familiar features already available through the NativeScript UI APIs:
 
 - Inline events
 - Different view modes
@@ -49,8 +49,8 @@ Calendar for Vue exposes all of the familiar features already available through 
 
 For more information on setting up and using a particular feature, take a look at the dedicated [article]({% slug calendar-getting-started-vue %} "Read more about RadCalendar with Vue.") in RadCalendar's documentation section. The articles are extended with Vue snippets and explanations where needed.
 
-## RadChart for Vue: overview
-Chart for Vue exposes all of the familiar features already available through the NativeScript UI APIs:
+## Chart for Vue: overview
+Chart for Vue (distributed through the `nativescript-ui-chart` package on npmjs) exposes all of the familiar features already available through the NativeScript UI APIs:
 
 - Series - LineSeries, SplineSeries, AreaSeries, BarSeries, RangeBarSeries, BubbleSeries, ScatterBubbleSeries, ScatterSeries, OhlcSeries, CandlestickSeries, PieSeries, DonutSeries
 - Axes - LinearAxis, CategoricalAxis, DateTimeCategoricalAxis
@@ -60,7 +60,7 @@ Chart for Vue exposes all of the familiar features already available through the
 For more information on setting up and using a particular feature, take a look at the dedicated [article]({% slug chart-getting-started-vue %} "Read more about RadCartesianChart with Vue.") in RadChart's documentation section. The articles are extended with Vue snippets and explanations where needed.
 
 ## DataForm for Vue: overview
-DataForm for Vue exposes all of the familiar features already available through the NativeScript UI APIs:
+DataForm for Vue (distributed through the `nativescript-ui-dataform` package on npmjs) exposes all of the familiar features already available through the NativeScript UI APIs:
 
 - Properties
 - Groups
@@ -70,7 +70,7 @@ DataForm for Vue exposes all of the familiar features already available through 
 For more information on setting up and using a particular feature, take a look at the dedicated [article]({% slug dataform-gettingstarted-vue %} "Read more about RadDataForm with Vue.") in RadDataForm's documentation section. The articles are extended with Vue snippets and explanations where needed.
 
 ## AutoComplete for Vue: overview
-AutoComplete for Vue exposes all of the familiar features already available through the NativeScript UI APIs:
+AutoComplete for Vue (distributed through the `nativescript-ui-autocomplete` package on npmjs) exposes all of the familiar features already available through the NativeScript UI APIs:
 
 - Suggest modes - Suggest, Append and SuggestAppend
 - Display modes - Plain and Tokens
@@ -80,7 +80,7 @@ AutoComplete for Vue exposes all of the familiar features already available thro
 For more information on setting up and using a particular feature, take a look at the dedicated [article]({% slug autocomplete-gettingstarted-vue%} "Read more about RadAutoComplete with Vue.") in RadAutoComplete's documentation section. The articles are extended with Vue snippets and explanations where needed.
 
 ## Gauge for Vue: overview
-Gauge for Vue exposes all of the familiar features already available through the NativeScript UI APIs:
+Gauge for Vue (distributed through the `nativescript-ui-gauge` package on npmjs) exposes all of the familiar features already available through the NativeScript UI APIs:
 
 - Scales
 - Indicators


### PR DESCRIPTION
Since `nativescript-ui-feedback`, `nativescript-ui-samples`, `nativescript-ui-samples-angular` and `nativescript-ui-samples-vue` repos have been transferred from `Telerik` to `NativeScript` some links are obsolete.