### PR TITLE
Updated the wrong exports function 

### DIFF
--- a/docs/core-concepts/events.md
+++ b/docs/core-concepts/events.md
@@ -72,7 +72,7 @@ Another option to set an event handler is to use an XML declaration. You need a 
 function onTouch(args) {
   console.log("Touch arguments: ", args);
 }
-exports.onTap = onTap;
+exports.onTouch = onTouch;
 ```
 ```TypeScript
 // main-page.ts


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] If there is an issue related with this PR, point it out here.

## What is the current state of the documentation article?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There's no `onTap `function in the sample code.
## What is the new state of the documentation article?
<!-- Describe the changes. -->
Updated to `exports.onTap = onTap`;
Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

