### PR TITLE
Updated ANDROID_HOME env variable value

### DIFF
--- a/docs/start/ns-setup-os-x.md
+++ b/docs/start/ns-setup-os-x.md
@@ -116,6 +116,7 @@ Complete the following steps to setup NativeScript on your macOS development mac
 
             <pre class="add-copy-button"><code class="language-terminal">export ANDROID_HOME=/usr/local/share/android-sdk
             </code></pre>
+            <blockquote><b>NOTE</b>: : If you are installing via Android SDK Manager, then the path for ANDROID_HOME would be '/Users/$userid/Library/Android/sdk/' .</blockquote>
 
             <blockquote><b>NOTE</b>: This is the directory that contains the <code>tools</code> and <code>platform-tools</code> directories.</blockquote>
             <blockquote><b>NOTE</b>: In order to persist these variables after your terminal session is closed, they have to be persisted in your shell profile file (e.g. <code>~/.bash_profile</code> if you are using Bash, <code>~/.zprofile if you are using Zsh)</blockquote>            


### PR DESCRIPTION
ANDROID_HOME env value if set as per documentation mentioned [here](https://github.com/NativeScript/nativescript-cli/issues/1813) does not work always. So updating that part as per the solution found.

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] If there is an issue related with this PR, point it out here.
https://github.com/NativeScript/nativescript-cli/issues/1813

## What is the current state of the documentation article?
Current documentation still does not fix the issue.

## What is the new state of the documentation article?
new state suggests possible solution with the note.

Fixes/Implements/Closes #[1813].


