### PR TITLE
#added App ID suffix in docs

### DIFF
--- a/docs/core-concepts/project-structure.md
+++ b/docs/core-concepts/project-structure.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Project Structure
 description: Learn the basic project structure of а NativeScript application - app, app resources, platforms
 position: 120

--- a/docs/sidekick/user-guide/code-signing/code-signing-for-ios/register-app-id.md
+++ b/docs/sidekick/user-guide/code-signing/code-signing-for-ios/register-app-id.md
@@ -8,23 +8,23 @@ slug: create-app-id
 
 # Register an App ID
 
-Before you can create a provisioning profile, you need to have a registered App ID. The iOS App ID uniquely identifies an application with the Apple application services and lets you incorporate them in your app. The Apple application services include Push Notifications, In-App Purchase, Game Center, to name a few.
+Before you can create a provisioning profile, you need to have a registered App ID with proper App ID suffix(Bundle ID). The iOS App ID and App ID suffix uniquely identifies an application with the Apple application services and lets you incorporate them in your app. The Apple application services include Push Notifications, In-App Purchase, Game Center, to name a few.
 
 You can register an App ID in the [iOS Dev Center](https://developer.apple.com/membercenter).
 
 ## Procedure
 1. Open [iOS Dev Center](https://developer.apple.com/membercenter) in your favorite browser and log in.
-1. Click **Certificates, Identifiers &amp; Profiles**.
-1. In the drop-down menu in the top left corner, verify that **iOS, tvOS, watchOS** is selected.
-1. In the left-hand sidebar, select **Identifiers** &#8594; **App IDs**.
-1. Click **+**.
-1. Type a description for your app in the **App ID Description** text box. The description is visible only in the [iOS Dev Center](https://developer.apple.com/membercenter) and will help you identify your App ID in the list of identifiers that are available to your Apple developer account.
-1. Select the type of App ID that you want to create and provide a bundle identifier.<br>Switching between the two types of ID might automatically change any selected app services.
+2. Click **Certificates, Identifiers &amp; Profiles**.
+3. In the drop-down menu in the top left corner, verify that **iOS, tvOS, watchOS** is selected.
+4. In the left-hand sidebar, select **Identifiers** &#8594; **App IDs**.
+5. Click **+**.
+6. Type a description for your app in the **App ID Description** text box. The description is visible only in the [iOS Dev Center](https://developer.apple.com/membercenter) and will help you identify your App ID in the list of identifiers that are available to your Apple developer account.
+7. Select the type of App ID that you want to create and provide a App Id suffix as **.org.nativescript** just in continuation to it.<br>Switching between the two types of ID might automatically change any selected app services.
 	* To use one App ID with multiple provisioning profiles, register a *wildcard App ID*. 
 	* If you want to build and publish an app with a unique App ID identifier and provisioning profile, register an *explicit App ID*.
-1. Select the app services that you want to incorporate in your application.
-1. Click **Continue**.
-1. Review the details for your App ID and click **Register** to confirm the registration.
+8. Select the app services that you want to incorporate in your application.
+9. Click **Continue**.
+10. Review the details for your App ID and click **Register** to confirm the registration.
 
 ## Next Steps
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] If there is an issue related with this PR, point it out here.

## What is the current state of the documentation article?
Docs do not contain any information about App ID suffix that's why the app registration process is somewhat incomplete

## What is the new state of the documentation article?
According to issue docs now contain information about App ID suffix and users now able to add it in their apps


Fixes/Implements/Closes #[Issue Number].
 

- [x] App ID suffix 

- [ ] Fetch (Unable to fine fetch module in docs)

 

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

