### PR TITLE
docs(angular-data-binding): Unescaped double-curly brackets do not display in browser

### DIFF
--- a/docs/core-concepts/angular-data-binding.md
+++ b/docs/core-concepts/angular-data-binding.md
@@ -83,7 +83,7 @@ This is the way Angular supports two-way data binding. It generally works in alm
 
 ## Interpolation 
 
-Angular mustache (`{{ }}`) syntax for binding a.k.a. interpolation is also supported within a NativeScript-Angular application. It's just another way of one-way binding placed in the middle of a text.
+Angular mustache {%raw%}(`{{ }}`){%endraw%} syntax for binding a.k.a. interpolation is also supported within a NativeScript-Angular application. It's just another way of one-way binding placed in the middle of a text.
 
 ```XML
 {%raw%}<Label text='{{model.deliveryHour}}:{{model.deliveryMinute}}'></Label>{%endraw%}


### PR DESCRIPTION
…playing in gitHub preview

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] If there is an issue related with this PR, point it out here.

## What is the current state of the documentation article?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new state of the documentation article?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

