### PR TITLE
fix: redirect code-sharing story to Angular only

### DIFF
--- a/build/nginx.conf
+++ b/build/nginx.conf
@@ -108,6 +108,9 @@ http {
 		rewrite ^(/angular)?/publishing/creating-launch-screens-ios $proto://$host_and_port$1/tooling/publishing/creating-launch-screens-ios permanent;
 		rewrite ^(/angular)?/publishing/creating-launch-screens-android $proto://$host_and_port$1/tooling/publishing/creating-launch-screens-android permanent;
 		
+		# Redirect Code Sharing story to Angular flavour
+		rewrite ^/code-sharing/intro $proto://$host_and_port/angular/code-sharing/intro permanent;
+
 		# Redirect base Angular link
 		rewrite ^/angular$ $proto://$host_and_port/angular/start/introduction permanent;
 		rewrite ^/angular/start/how-it-works$ $proto://$host_and_port/angular/core-concepts/technical-overview permanent;


### PR DESCRIPTION
Explicit redirect for Code sharing section https://docs.nativescript.org/code-sharing/intro to  https://docs.nativescript.org/angular/code-sharing/intro (Angular flavor)