### PR TITLE
Updated the @import for the theme css example

### DIFF
--- a/docs/start/cli-basics.md
+++ b/docs/start/cli-basics.md
@@ -175,7 +175,7 @@ Let’s make one final change.
 Find the first line of your app’s `app/app.css` file, which imports a `core.light.css` file. This import tells NativeScript to use a “light” color scheme. Let’s change to the “sky” color scheme by replacing the existing line of code with the one shown below.
 
 ``` CSS
-@import "nativescript-theme-core/css/sky.css";
+@import '~nativescript-theme-core/css/sky.css';
 ```
 
 <div class="exercise-end"></div>


### PR DESCRIPTION
The old one doesnt seem to work and the tilde one is whats listed on the https://docs.nativescript.org/ui/theme#color-schemes page.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.

## What is the new state of the documentation article?
Changed the @import for the theme css example as the previous one doesnt seem to work. Changed it to what is listed on this page: https://docs.nativescript.org/ui/theme#color-schemes

