### PR TITLE
docs: update node version to latest LTS

### DIFF
--- a/docs/sidekick/intro/installation.md
+++ b/docs/sidekick/intro/installation.md
@@ -10,7 +10,7 @@ slug: installation
 
 ## Step 1: Install Node.js
 
-To run {{ site.ns-sk }}, you need to have Node.js installed on your machine. To check whether Node.js is installed on your development machine, you should open a terminal or command prompt and run the `node --version` command. If you get an error, head to [https://nodejs.org/](https://nodejs.org/en/) and download and install the latest [Node.js LTS](https://github.com/nodejs/LTS#lts-schedule) version. We recommend using [Node.js 8.x](https://nodejs.org/dist/latest-v8.x/).
+To run {{ site.ns-sk }}, you need to have Node.js installed on your machine. To check whether Node.js is installed on your development machine, you should open a terminal or command prompt and run the `node --version` command. If you get an error, head to [https://nodejs.org/](https://nodejs.org/en/) and download and install the latest [Node.js LTS](https://github.com/nodejs/LTS#lts-schedule) version. We recommend using [Node.js 10.x](https://nodejs.org/dist/latest-v10.x/).
 
 ## Step 2: Install the {{ site.ns-cli }}
 


### PR DESCRIPTION
Bump suggested node version from 8.x to 10.x (current LTS). Sidekick installation specifically requires NodesJS >= 10.0.0 <10.6.0 || >=10.10.0

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] If there is an issue related with this PR, point it out here.

## What is the current state of the documentation article?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new state of the documentation article?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

