### PR TITLE
fix(code-sharing): redirect removed article url

### DIFF
--- a/build/nginx.conf
+++ b/build/nginx.conf
@@ -114,6 +114,9 @@ http {
 		# Redirect Code Sharing story to Angular flavour
 		rewrite ^/code-sharing/intro $proto://$host_and_port/angular/code-sharing/intro permanent;
 
+        # Redirect removed article to the Code Sharing intro
+		rewrite ^/angular/code-sharing/platform-specific-components $proto://$host_and_port/angular/code-sharing/intro permanent;
+
 		# Redirect base Angular link
 		rewrite ^/angular$ $proto://$host_and_port/angular/start/introduction permanent;
 		rewrite ^/angular/start/how-it-works$ $proto://$host_and_port/angular/core-concepts/technical-overview permanent;


### PR DESCRIPTION
This redirects the removed `Platform-specific components` article to `Code Sharing Introduction`.