### PR TITLE
Add docs for gradle.properties support

### DIFF
--- a/docs/core-concepts/android-runtime/advanced-topics/gradle-hooks.md
+++ b/docs/core-concepts/android-runtime/advanced-topics/gradle-hooks.md
@@ -7,13 +7,23 @@ slug: gradle-hooks
 
 # Gradle Hooks
 
-NativeScript uses gradle to build android applications. The gradle build files are part of the application template that comes from the android runtime package. Sometimes, if you want to use any external plugins or libraries you need to add some code to the gradle files. There are several locations for gradle files that can be used for adding your code. They are applied in the build process in the following order:
+NativeScript uses gradle to build android applications. The gradle build files are part of the application template that comes from the android runtime package. Sometimes, if you want to use any external plugins or libraries you need to add some code to the gradle files. There are several locations for gradle files that can be used for adding your code or gradle properties. They are applied in the build process in the following order:
 
-1. `App_Resources/Android/buildscript.gradle`
-2. plugins' `buildscript.gradle`
-3. `App_Resources/Android/before-plugins.gradle`
-4. plugins' `include.gradle`
-5. `App_Resources/Android/app.gradle`
+1. `App_Resources/Android/gradle.properties`
+2. `App_Resources/Android/buildscript.gradle`
+3. plugins' `buildscript.gradle`
+4. `App_Resources/Android/before-plugins.gradle`
+5. plugins' `include.gradle`
+6. `App_Resources/Android/app.gradle`
+
+## gradle.properties
+
+In this file you can set various properties which could be used at a later point in the gradle script files. For example, if you want to define the variable `myCustomVariable` with a value `myCustomValue`, you would need to add the following in your `gradle.properties` file:
+
+```Groovy
+myCustomVariable=myCustomValue
+```
+Then, in your gradle script file, you can access the property by accessing it on the `project` object as `project.myCustomVariable`
 
 ## app.gradle
 

--- a/docs/core-concepts/android-runtime/advanced-topics/gradle-hooks.md
+++ b/docs/core-concepts/android-runtime/advanced-topics/gradle-hooks.md
@@ -23,7 +23,7 @@ In this file you can set various properties which could be used at a later point
 ```Groovy
 myCustomVariable=myCustomValue
 ```
-Then, in your gradle script file, you can access the property by accessing it on the `project` object as `project.myCustomVariable`
+Then, in your gradle script file, you can access the property by accessing it on the `project` object as `project.myCustomVariable`.
 
 ## app.gradle
 


### PR DESCRIPTION
Added documentation about the `gradle.properties` file used for setting gradle project properties.