### PR TITLE
fix: redirect a couple of Angular-specific articles to the Angular flavour of the docs

### DIFF
--- a/build/nginx.conf
+++ b/build/nginx.conf
@@ -118,6 +118,12 @@ http {
 		# Redirect Code Sharing story to Angular flavour
 		rewrite ^/code-sharing/intro $proto://$host_and_port/angular/code-sharing/intro permanent;
 
+        # Redirect Lazy Loading article to Angular flavour
+		rewrite ^/performance-optimizations/lazy-loading $proto://$host_and_port/angular/performance-optimizations/lazy-loading permanent;
+
+        # Redirect Angular Navigation article to Angular flavour
+		rewrite ^/core-concepts/angular-navigation $proto://$host_and_port/angular/core-concepts/angular-navigation permanent;
+
         # Redirect removed article to the Code Sharing intro
 		rewrite ^/angular/code-sharing/platform-specific-components $proto://$host_and_port/angular/code-sharing/intro permanent;
 


### PR DESCRIPTION
This PR changes the NGINX configuration to redirect:

- https://docs.nativescript.org/performance-optimizations/lazy-loading to https://docs.nativescript.org/angular/performance-optimizations/lazy-loading
- https://docs.nativescript.org/core-concepts/angular-navigation to https://docs.nativescript.org/angular/core-concepts/angular-navigation