### PR TITLE
1. Ubuntu 19.x pkg version 2. Missing step

### DIFF
--- a/docs/start/ns-setup-linux.md
+++ b/docs/start/ns-setup-linux.md
@@ -43,6 +43,7 @@ Complete the following steps to set up NativeScript on your Linux development ma
     If you encounter an error showing "Unable to locate package lib32bz2-1.0" then use
     <pre class="add-copy-button"><code class="language-terminal">sudo apt-get install lib32z1 lib32ncurses5 libbz2-1.0:i386 libstdc++6:i386
     </code></pre>
+    Package `lib32ncurses5` is only available as version 6 on Ubuntu >v.19.04, replace with `lib32ncurses6`. 
 
 3. Install the G++ compiler.
 
@@ -63,7 +64,8 @@ Complete the following steps to set up NativeScript on your Linux development ma
 
     3. Set the JAVA_HOME system environment variable. Open `~/.bashrc` and add the following:
 
-        <pre class="add-copy-button"><code class="language-terminal">export JAVA_HOME=$(update-alternatives --query javac | sed -n -e 's/Best: *\(.*\)\/bin\/javac/\1/p')</code></pre>
+        <pre class="add-copy-button"><code class="language-terminal">export JAVA_HOME=$(update-alternatives --query javac | sed -n -e 's/Best: *\(.*\)\/bin\/javac/\1/p')</code></pre>  
+        You may need to reload the `bashrc`file either by logging out and in again, or by running `source .bashrc` in the terminal from your Home directory.  
 
 5. Install the [Android SDK](http://developer.android.com/sdk/index.html).
     1. Go to [Android Studio and SDK Downloads](https://developer.android.com/sdk/index.html#Other) and in the **SDK Tools Only** section download the package for Linux at the bottom of the page.


### PR DESCRIPTION
1. The latest ubuntu, 19.04 and above include lib32ncurses package with a version number in the name, meaning the given install one-liner will fail with a "package not found" error. Added a note to that effect. 
2. Adding the JAVA_HOME path to bashrc will not take effect until bashrc is reloaded either by logging out and in again or by forcing reload with `$ source .bashrc`from the user's ~/HOME directory. Added that information.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] If there is an issue related with this PR, point it out here.

## What is the current state of the documentation article?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new state of the documentation article?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

