### PR TITLE
fix: feedback bar margin on Safari

### DIFF
--- a/build/_assets/stylesheets/styles.css
+++ b/build/_assets/stylesheets/styles.css
@@ -1281,7 +1281,7 @@ a.ns-card:hover {
 /* Footer */
 
 .ns-footer {
-    z-index: 2;
+    z-index: 0;
     font-size: .88em;
     position: relative;
     width: calc(100% + 600px);


### PR DESCRIPTION
Fixes margin issues on Safari without breaking IE/Firefox/or Chrome.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] If there is an issue related with this PR, point it out here.

## What is the current state of the documentation article?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
ns-footer currently breaks when Safari is zoomed in past 100%

## What is the new state of the documentation article?
<!-- Describe the changes. -->
Removed z-index from ns-footer, effectively fixing margin issues.

Fixes/Implements/Closes #[1622].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

