### PR TITLE
docs: fix link to UI Components' `migration documentation`

### DIFF
--- a/docs/releases/changes.md
+++ b/docs/releases/changes.md
@@ -24,7 +24,7 @@ NativeScript consists of several parts that ideally, would get released at their
 [NativeScript Android Runtime Changelog](https://github.com/NativeScript/android-runtime/releases)
 
 ## Professional UI Components - NativeScript UI
-Since version 3.5.0, `nativescript-pro-ui` is deperecated and each component has been moved to its [own plugin](https://www.nativescript.org/blog/professional-components-from-nativescript-ui-the-big-breakup). Below are the links for the release notes of each of the plugins. In case you need to migrate, read the relevant [migration documentation]({% slug nativescript-ui-migration %}).
+Since version 3.5.0, `nativescript-pro-ui` is deprecated and each component has been moved to its [own plugin](https://www.nativescript.org/blog/professional-components-from-nativescript-ui-the-big-breakup). Below are the links for the release notes of each of the plugins. In case you need to migrate, read the relevant [migration documentation](/5-4/ui/professional-ui-components/migration).
 
 -  [AutoComplete](https://github.com/NativeScript/nativescript-ui-feedback/blob/master/releases/autocomplete.md)
 -  [Calendar](https://github.com/NativeScript/nativescript-ui-feedback/blob/master/releases/calendar.md)


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] If there is an issue related with this PR, point it out here.

## What is the current state of the documentation article?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
https://github.com/NativeScript/docs/issues/1810

## What is the new state of the documentation article?
<!-- Describe the changes. -->
- fixes UI Components' `migration documentation` link in Changes article
- fixes a small typo

Fixes #1810.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

