### PR TITLE
docs: fix broken link to external "How NativeScript Works" article

### DIFF
--- a/docs/core-concepts/technical-overview.md
+++ b/docs/core-concepts/technical-overview.md
@@ -29,7 +29,3 @@ It is the command-line interface that lets you create, build, and run apps using
 ## NativeScript Plugins
 
 The NativeScript plugins are building blocks that encapsulate some functionality and help developers build apps faster (just like the NativeScript Core Modules, which is a plugin). Most are community-built, written in TypeScript/JavaScript. Some can include native libraries, which are called from the TS/JS code thanks to the Runtimes. You can find more information in the [Plugins documentation](../plugins/plugins.md).
-
-## See also
-* [How NativeScript Works article on developer.telerik.com](https://developer.telerik.com/featured/nativescript-works/)
-


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] If there is an issue related with this PR, point it out here.

## What is the current state of the documentation article?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
https://github.com/NativeScript/docs/issues/1807

## What is the new state of the documentation article?
<!-- Describe the changes. -->
Removes the link `How NativeScript Works article on developer.telerik.com`
in the Technical Overview article. This article doesn't appear
to exist anywhere on the NativeScript blog.

Fixes #1807.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

