### PR TITLE
docs: fix broken links to Professional UI components

### DIFF
--- a/docs/app-templates/app-templates.md
+++ b/docs/app-templates/app-templates.md
@@ -56,7 +56,7 @@ Github repo: https://github.com/NativeScript/nativescript-app-templates/tree/mas
 Github repo: https://github.com/NativeScript/nativescript-app-templates/tree/master/packages/template-drawer-navigation-ng
 {% endangular %}
 
-This template contains a preconfigured {% nativescript %}[SideDrawer]({% slug sidedrawer-overview %}){% endnativescript %}{% angular %}[SideDrawer]({% slug sidedrawer-overview-angular %}){% endangular %} component from the [Progress NativeScript UI]({% slug ns-ui-overview %}) suite with several pages.
+This template contains a preconfigured {% nativescript %}[SideDrawer]({% slug sidedrawer-overview %}){% endnativescript %}{% angular %}[SideDrawer]({% slug sidedrawer-overview-angular %}){% endangular %} component from [NativeScript UI's built-in components]({% slug components %}) with several pages.
 
 ## Tabs
 

--- a/docs/core-concepts/angular-navigation.md
+++ b/docs/core-concepts/angular-navigation.md
@@ -994,7 +994,7 @@ export class SearchComponent implements OnInit {
 
 ### SideDrawer Navigation
 
-The `SideDrawer` component is part of the [Professional UI Components]({%slug ns-ui-overview %}) suite. It enables the user to open a hidden view, i.e. drawer, containing navigation controls, or settings from the sides of the screen. There are a lot of navigation patterns that can be implemented using a `SideDrawer`. A typical usage would be to add UI controls and have them do one of two things:
+The `SideDrawer` component is part of [NativeScript UI's built-in components]({%slug components %}). It enables the user to open a hidden view, i.e. drawer, containing navigation controls, or settings from the sides of the screen. There are a lot of navigation patterns that can be implemented using a `SideDrawer`. A typical usage would be to add UI controls and have them do one of two things:
 
 * Forward navigation - navigate in a `page-router-outlet`.
 * Lateral navigation - open a modal view.

--- a/docs/core-concepts/navigation.md
+++ b/docs/core-concepts/navigation.md
@@ -384,7 +384,7 @@ export function closeModal(args: EventData) {
 
 ### SideDrawer Navigation
 
-The `SideDrawer` component is part of the [Professional UI Components]({%slug ns-ui-overview %}) suite. It enables the user to open a hidden view, i.e. drawer, containing navigation controls, or settings from the sides of the screen. There are a lot of navigation patterns that can be implemented using a `SideDrawer`. A typical usage would be to add UI controls and have them do one of two things:
+The `SideDrawer` component is part of [NativeScript UI's built-in components]({%slug components %}). It enables the user to open a hidden view, i.e. drawer, containing navigation controls, or settings from the sides of the screen. There are a lot of navigation patterns that can be implemented using a `SideDrawer`. A typical usage would be to add UI controls and have them do one of two things:
 
 * Forward navigation - get a reference to a navigation `Frame` and navigate in it.
 * Lateral navigation - open a modal view.


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] If there is an issue related with this PR, point it out here.

## What is the current state of the documentation article?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
https://github.com/NativeScript/docs/issues/1792

## What is the new state of the documentation article?
<!-- Describe the changes. -->
Fixes links with the `slug ns-ui-overview` with the
correct `slug components`.

Fixes #1792 .

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

