### PR TITLE
Add an empty afterAll to the TestBed exmaple

### DIFF
--- a/docs/tooling/testing/testing.md
+++ b/docs/tooling/testing/testing.md
@@ -177,6 +177,7 @@ export class ZonedRenderer {
 describe('Renderer E2E', () => {
     beforeEach(nsTestBedBeforeEach([ZonedRenderer]));
     afterEach(nsTestBedAfterEach(false));
+    afterAll(() => {});
 
     it('executes events inside NgZone when listen is called outside NgZone', async(() => {
         const eventName = 'someEvent';


### PR DESCRIPTION
This fixes 
JS: NSUTR: this.error: An error was thrown in afterAll
JS: TypeError: Cannot read property 'origin' of undefined
NativeScript / 29 (10; Android SDK built for x86)  undefined at line undefined FAILED
        An error was thrown in afterAll
        TypeError: Cannot read property 'origin' of undefined
            at <Jasmine>
            at ZoneQueueRunner.push.../node_modules/@nativescript/angular/zone-js/dist/zone-nativescript.jasmine.js.jasmine.QueueRunner.ZoneQueueRunner.execute (file:///data/data/org.nativescript.firstapp/files/app/vendor.js:84532:42)
            at <Jasmine>
NativeScript / 29 (10; Android SDK built for x86): Executed 1 of 1 (1 FAILED) (0.237 secs / 0 secs)

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] If there is an issue related with this PR, point it out here.

## What is the current state of the documentation article?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new state of the documentation article?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

