### PR TITLE
fix: Broken "Improve this article" links

### DIFF
--- a/build/_config.yml
+++ b/build/_config.yml
@@ -187,6 +187,26 @@ improveThis:
             trimRootPath: "/tooling/docs-cli"
             baseUrl: "https://github.com/NativeScript/nativescript-cli/tree/master/docs/man_pages"
         3:
+            matchPattern: '^/ui/ng-components/(icon-fonts|modal-view-ng).*'
+            trimRootPath: "/ui/ng-components/"
+            pathUpdatePattern: ".md$"
+            baseUrl: "https://github.com/NativeScript/nativescript-sdk-examples-ng/tree/master/app/ng-ui-category/"
+        4:
+            matchPattern: '^/ui/ng-components/.*'
+            trimRootPath: "/ui/ng-components/"
+            pathUpdatePattern: ".md$"
+            baseUrl: "https://github.com/NativeScript/nativescript-sdk-examples-ng/tree/master/app/ng-ui-widgets-category/"
+        5:
+            matchPattern: '^/ui/components/(icon-fonts|modal-view).*'
+            trimRootPath: "/ui/components/"
+            pathUpdatePattern: ".md$"
+            baseUrl: "https://github.com/NativeScript/nativescript-sdk-examples-js/tree/master/app/ns-ui-category"
+        6:
+            matchPattern: '^/ui/components/.*'
+            trimRootPath: "/ui/components/"
+            pathUpdatePattern: ".md$"
+            baseUrl: "https://github.com/NativeScript/nativescript-sdk-examples-js/tree/master/app/ns-ui-widgets-category/"
+        7:
             matchPattern: '.*'
             baseUrl: "https://github.com/NativeScript/docs/blob/master/docs/"
 


### PR DESCRIPTION
SDK examples articles were not handled correctly. Link to the
corresponding article's directory in its repective repository, as each
article is made up of multiple sub-sections gathered from different
files.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] If there is an issue related with this PR, point it out here.

## What is the current state of the documentation articles?
Contain broken "Improve this article" link

## What is the new state of the documentation article?
"Improve this article" link points to the correct directory in GitHub
