### PR TITLE
docs(animation.md): explain limitations regarding Span and FormattedText

### DIFF
--- a/docs/ui/animation.md
+++ b/docs/ui/animation.md
@@ -203,3 +203,7 @@ view.animate({
 ```
 
 > Note: The properties `originX` and `originY` are JavaScript properties and can be assigned via code-behind only via a given `View` reference. We can still use them along with CSS animations, but the values for `originX` and `originY` must be set in the code-behind logic.
+
+## Limitations
+
+- `Span` and `FormattedString` can not be animated. `Span` and `FormattedString` elements are not extending the [`View`](https://docs.nativescript.org/api-reference/classes/__nativescript_core_.view) class, but only [`ViewBase`](https://docs.nativescript.org/api-reference/classes/__nativescript_core_.viewbase). Because of this, neither `Span` nor `FormattedString` are ui elements, making it impossible to animate them and causing a crash on iOS.


### PR DESCRIPTION
According to issue #8359, Span and FormattedString cannot be animated, because they are no ui elements. Since the error message is not that helpful for most people, I believe, this should be documented.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] If there is an issue related with this PR, point it out here.

## What is the current state of the documentation article?
The documentation article doesn't mention any limitations regarding `Span` and `FormattedString` elements.

## What is the new state of the documentation article?
Added a Limitations section the end containing list item concerning `Span` and `FormattedString`.

Fixes/Implements/Closes #8359.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

