### PR TITLE
update chocolatey windows install command

### DIFF
--- a/docs/start/ns-setup-win.md
+++ b/docs/start/ns-setup-win.md
@@ -25,7 +25,7 @@ Complete the following steps to set up NativeScript on your Windows development 
     - Run the command prompt as an Administrator.
     - Copy and paste the following script in the command prompt.
 
-        <pre class="add-copy-button"><code class="language-terminal">@powershell -NoProfile -ExecutionPolicy unrestricted -Command "iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))" && SET PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin
+        <pre class="add-copy-button"><code class="language-terminal">Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
         </code></pre>
     - Restart the command prompt.
 


### PR DESCRIPTION
new chocolatey windows install command, pasted from chocolatey.org, 
because old command throws errors:

````
PS C:\WINDOWS\system32> @powershell -ExecutionPolicy unrestricted -Command "iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))" && SET PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin
In Zeile:1 Zeichen:13
+ @powershell -ExecutionPolicy unrestricted -Command "iex ((new-object  ...
+             ~~~~~~~~~~~~~~~~
Unerwartetes Token "-ExecutionPolicy" in Ausdruck oder Anweisung.
In Zeile:1 Zeichen:30
+ @powershell -ExecutionPolicy unrestricted -Command "iex ((new-object  ...
+                              ~~~~~~~~~~~~
Unerwartetes Token "unrestricted" in Ausdruck oder Anweisung.
In Zeile:1 Zeichen:140
+ ... nt).DownloadString('https://chocolatey.org/install.ps1'))" && SET PAT ...
+                                                                ~~
Das Token "&&" ist in dieser Version kein gültiges Anweisungstrennzeichen.
In Zeile:1 Zeichen:1
+ @powershell -ExecutionPolicy unrestricted -Command "iex ((new-object  ...
+ ~~~~~~~~~~~
Der Splat-Operator "@" kann nicht dazu verwendet werden, auf Variablen in einem Ausdruck zu verweisen. "@powershell"
kann nur als Argument für einen Befehl verwendet werden. Wenn Sie auf Variablen in einem Ausdruck verweisen möchten,
verwenden Sie "$powershell".
    + CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : UnexpectedToken

````


