### PR TITLE
feat: No need to show 'Combining Nested Navigation Scenarios' section in Angular guide

### DIFF
--- a/docs/core-concepts/nested-navigation.md
+++ b/docs/core-concepts/nested-navigation.md
@@ -224,10 +224,10 @@ TabView (lateral navigation)
 [Playground Demo Angular](https://play.nativescript.org/?template=play-ng&id=ObeDAp)
 {% endangular %}
 
-
+{% nativescript %}
 ## Combining Nested Navigation Scenarios
 
-{% nativescript %}
+
 ![navigation-schema-backward](../img/navigation-extended/navigation-examples-page-7.png?raw=true)
 
 The following example demonstrates a scenario where we have combined several nested navigations (both lateral and forward navigations on different nested levels). For example, a `RadSidedrawer` + Login page leading to a page with a `TabView` and in one `TabView` there are inner forward navigations in each tab item. There is also a modal page with its own forward navigation.


### PR DESCRIPTION
Since there is no Angular code under 'Combining Nested Navigation Scenarios' section, I don't think we should show it under angular doc.

It confused me when I see only header like this without the body:

<img width="1561" alt="Screen Shot 2563-03-28 at 19 21 14" src="https://user-images.githubusercontent.com/3887531/77822990-42b5d780-712a-11ea-85e9-63fe5641be87.png">

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [X] If there is an issue related with this PR, point it out here.

## What is the current state of the documentation article?
I see a section called 'Combining Nested Navigation Scenarios' in [Angular guide](https://docs.nativescript.org/angular/core-concepts/nested-navigation#nesting-lateral-in-lateral), however I don't see the section's body (describing code, etc.). However, both title and body are shown under normal [NativeScript guide](https://docs.nativescript.org/core-concepts/nested-navigation#nesting-lateral-in-lateral).

I think it'd make more sense to bring back this section in Angular guide once the code is ready. For now we better hide it so there is no confusion. Otherwise, we can show it but at least show some text saying things like 'For this section, only NativeScript is available, click here to see it', or something like that.

## What is the new state of the documentation article?
I make the webpage hide the 'Combining Nested Navigation Scenarios' section in the Angular guide, it'll still show up as usual under normal NativeScript guide.

