### PR TITLE
feat: add explicit note about the example app

### DIFF
--- a/docs/ui/components/AutoCompleteTextView/autocomplete-getting-started.md
+++ b/docs/ui/components/AutoCompleteTextView/autocomplete-getting-started.md
@@ -10,7 +10,7 @@ publish: true
 
 # RadAutoCompleteTextView Getting Started
 
-In this article, you will learn how to initialize **RadAutoCompleteTextView** and use it with its basic configuration.
+In this article, you will learn how to initialize **RadAutoCompleteTextView** and use it with its basic configuration. The code snippets from this section are available as [a standalone demo application](https://github.com/NativeScript/nativescript-ui-samples).
 
 ## Installation
 **RadAutoCompleteTextView** is distributed through the `nativescript-ui-autocomplete` package, so before using it, you need to run the following command to add the plugin to your application:

--- a/docs/ui/components/Calendar/getting-started.md
+++ b/docs/ui/components/Calendar/getting-started.md
@@ -9,7 +9,7 @@ publish: true
 ---
 
 # RadCalendar Getting Started
-This article will guide you through the process of adding a {% typedoc_link classes:RadCalendar %} instance to a page in a **{N}** application.
+This article will guide you through the process of adding a {% typedoc_link classes:RadCalendar %} instance to a page in a **{N}** application. The code snippets from this section are available as [a standalone demo application](https://github.com/NativeScript/nativescript-ui-samples).
 
 ## Installation
 Run the following command to add the plugin to your application:

--- a/docs/ui/components/Chart/getting-started.md
+++ b/docs/ui/components/Chart/getting-started.md
@@ -10,7 +10,7 @@ publish: true
 
 # Chart Getting Started
 
-In this article, you will learn to start using NativeScript UI Chart: how to initialize the chart, how to create the data series and how to use the different axes.
+In this article, you will learn to start using NativeScript UI Chart: how to initialize the chart, how to create the data series and how to use the different axes. The code snippets from this section are available as [a standalone demo application](https://github.com/NativeScript/nativescript-ui-samples).
 
 * [Plugin Installation](#plugin-installation)
 * [Data Model](#data-model)

--- a/docs/ui/components/Gauge/getting-started.md
+++ b/docs/ui/components/Gauge/getting-started.md
@@ -10,7 +10,7 @@ publish: true
 
 # RadGauge Getting Started
 
-This article will guide you through the process of adding a {% typedoc_link classes:RadRadialGauge %} instance to a page in a {N} application and adding scales and indicators to it.
+This article will guide you through the process of adding a {% typedoc_link classes:RadRadialGauge %} instance to a page in a {N} application and adding scales and indicators to it. The code snippets from this section are available as [a standalone demo application](https://github.com/NativeScript/nativescript-ui-samples).
 
 #### Figure 1. Radial gauge with needle and bar indicators
 ![NativeScriptUI-Getting-Started-iOS](../../img/ns_ui/gauges-gettingstarted-ios.png "RadRadialGauge in iOS") ![NativeScriptUI-Getting-Started-Android](../../img/ns_ui/gauges-gettingstarted-android.png "RadRadialGauge in Android") 

--- a/docs/ui/components/RadListView/getting-started.md
+++ b/docs/ui/components/RadListView/getting-started.md
@@ -8,7 +8,7 @@ position: 2
 publish: true
 ---
 # RadListView Getting Started
-This article will guide you through the process of adding a RadListView in your application, binding it to a data-source and visualizing the items by using an item template of your choice. For more information on how each separate feature of {% typedoc_link classes:RadListView %} is used, please refer to the dedicated articles which are using the same scenario and extend it further.
+This article will guide you through the process of adding a RadListView in your application, binding it to a data-source and visualizing the items by using an item template of your choice. For more information on how each separate feature of {% typedoc_link classes:RadListView %} is used, please refer to the dedicated articles which are using the same scenario and extend it further. The code snippets from this section are available as [a standalone demo application](https://github.com/NativeScript/nativescript-ui-samples).
 
 ## Installation
 Run the following command to add the plugin to your application:

--- a/docs/ui/components/SideDrawer/getting-started.md
+++ b/docs/ui/components/SideDrawer/getting-started.md
@@ -9,7 +9,8 @@ publish: true
 ---
 
 # RadSideDrawer Getting Started
-This article will guide you through the process of adding a {% typedoc_link classes:RadSideDrawer %} instance to a page in your NativeScript application and initializing its content. 
+This article will guide you through the process of adding a {% typedoc_link classes:RadSideDrawer %} instance to a page in your NativeScript application and initializing its content. The code snippets from this section are available as [a standalone demo application](https://github.com/NativeScript/nativescript-ui-samples).
+
 > By design the `RadSideDrawer` is designed to be placed as a single child to your `Page`. For example:
 ```XML
 <Page>

--- a/docs/ui/ng-components/ng-AutoCompleteTextView/getting-started.md
+++ b/docs/ui/ng-components/ng-AutoCompleteTextView/getting-started.md
@@ -10,7 +10,7 @@ publish: true
 
 # RadAutoCompleteTextView Getting Started
 
-In this article, you will learn how to initialize **RadAutoCompleteTextView** and use it with its basic configuration inside an NativeScript + Angular applications. 
+In this article, you will learn how to initialize **RadAutoCompleteTextView** and use it with its basic configuration inside an NativeScript + Angular applications. The code snippets from this section are available as [a standalone demo application](https://github.com/NativeScript/nativescript-ui-samples-angular).
 
 ## Installation
 **RadAutoCompleteTextView** is distributed through the `nativescript-ui-autocomplete` package, so before using it, you need to run the following command to add the plugin to your application:
@@ -141,5 +141,5 @@ And here's how RadAutoCompleteTextView looks when the above CSS is applied:
 Want to see this scenario in action?
 Check our SDK examples repo on GitHub. You will find this and many other practical examples with NativeScript UI.
 
-* [RadAutoCompleteTextView Examples](https://github.com/NativeScript/nativescript-ui-samples/tree/master/autocomplete/app/examples/getting-started)
+* [RadAutoCompleteTextView Examples](https://github.com/NativeScript/nativescript-ui-samples-angular/tree/master/autocomplete/app/examples/getting-started)
 

--- a/docs/ui/ng-components/ng-Calendar/getting-started.md
+++ b/docs/ui/ng-components/ng-Calendar/getting-started.md
@@ -9,7 +9,7 @@ publish: true
 ---
 
 # Getting Started with RadCalendar for Angular 
-This article will guide you through the process of adding a RadCalendar in your application. For more information on how each separate feature of {% typedoc_link classes:RadCalendar %} is used, please refer to the dedicated articles.
+This article will guide you through the process of adding a RadCalendar in your application. For more information on how each separate feature of {% typedoc_link classes:RadCalendar %} is used, please refer to the dedicated articles. The code snippets from this section are available as [a standalone demo application](https://github.com/NativeScript/nativescript-ui-samples-angular).
 
 ## Installation
 Run the following command to add the plugin to your application:

--- a/docs/ui/ng-components/ng-Chart/getting-started.md
+++ b/docs/ui/ng-components/ng-Chart/getting-started.md
@@ -10,7 +10,7 @@ publish: true
 
 # Chart Getting Started
 
-In this article, you will learn to start using NativeScript UI Chart: how to initialize the chart, how to create the data series and how to use the different axes.
+In this article, you will learn to start using NativeScript UI Chart: how to initialize the chart, how to create the data series and how to use the different axes. The code snippets from this section are available as [a standalone demo application](https://github.com/NativeScript/nativescript-ui-samples-angular).
 
 * [Plugin Installation](#plugin-installation)
 * [Add Chart to Component Template](#add-chart-to-component-template)

--- a/docs/ui/ng-components/ng-Gauge/getting-started.md
+++ b/docs/ui/ng-components/ng-Gauge/getting-started.md
@@ -10,7 +10,7 @@ publish: true
 
 # RadGauge Getting Started
 
-This article will guide you through the process of adding a {% typedoc_link classes:RadRadialGauge %} instance to a page in a {N} application and adding scales and indicators to it.
+This article will guide you through the process of adding a {% typedoc_link classes:RadRadialGauge %} instance to a page in a {N} application and adding scales and indicators to it. The code snippets from this section are available as [a standalone demo application](https://github.com/NativeScript/nativescript-ui-samples-angular).
 
 #### Figure 1. Radial gauge with needle and bar indicators
 ![NativeScriptUI-Getting-Started-iOS](../../img/ns_ui/gauges-gettingstarted-ios.png "RadRadialGauge in iOS") ![NativeScriptUI-Getting-Started-Android](../../img/ns_ui/gauges-gettingstarted-android.png "RadRadialGauge in Android") 

--- a/docs/ui/ng-components/ng-RadListView/getting-started.md
+++ b/docs/ui/ng-components/ng-RadListView/getting-started.md
@@ -9,7 +9,7 @@ publish: true
 ---
 
 # RadListView for Angular - Getting started
-{% typedoc_link classes:RadListView %} for Angular is exposed through the {% typedoc_link classes:RadListViewComponent %} class. This article will guide you through the process of adding a {% typedoc_link classes:RadListViewComponent %} in your application, binding it to a data-source and visualizing the items by using an item template of your choice. For more information on how each separate feature of {% typedoc_link classes:RadListViewComponent %} is used, please refer to the dedicated articles which are using the same scenario and extend it further.
+{% typedoc_link classes:RadListView %} for Angular is exposed through the {% typedoc_link classes:RadListViewComponent %} class. This article will guide you through the process of adding a {% typedoc_link classes:RadListViewComponent %} in your application, binding it to a data-source and visualizing the items by using an item template of your choice. For more information on how each separate feature of {% typedoc_link classes:RadListViewComponent %} is used, please refer to the dedicated articles which are using the same scenario and extend it further. The code snippets from this section are available as [a standalone demo application](https://github.com/NativeScript/nativescript-ui-samples-angular).
 
 ## Installation
 Run the following command to add the plugin to your application:

--- a/docs/ui/ng-components/ng-SideDrawer/getting-started.md
+++ b/docs/ui/ng-components/ng-SideDrawer/getting-started.md
@@ -9,7 +9,7 @@ publish: true
 ---
 
 # RadSideDrawer Getting Started
-This article explains how to create a simple RadSideDrawer with Angular.
+This article explains how to create a simple RadSideDrawer with Angular. The code snippets from this section are available as [a standalone demo application](https://github.com/NativeScript/nativescript-ui-samples-angular).
 
 > The `RadSideDrawer` is designed to be placed as a single child in your component's HTML.
  This rule excludes the use of a `<ActionBar>` which is not treated as a simple element by NativeScript and can be used with `RadSideDrawer` by placing it at the beginning of the HTML. 


### PR DESCRIPTION
Related to:

> People have problems finding the complete {N} UI examples that are linked on their Getting Started page:
> https://docs.nativescript.org/ui/components/AutoCompleteTextView/autocomplete-getting-started#references
> docs.nativescript.orgdocs.nativescript.org
> Getting Started - NativeScript Docs
> A getting started page for RadAutoCompleteTextView for Android. This article explains what are the steps to create a RadAutoCompleteTextView instance from scratch.
> 6:55
> Maybe a big hint in the Overview pages will do? :slightly_smiling_face: