### PR TITLE
Markdown problems with firefox

### DIFF
--- a/vuejs-docs/ns-ui/DataForm/dataform-validation.md
+++ b/vuejs-docs/ns-ui/DataForm/dataform-validation.md
@@ -48,7 +48,9 @@ Here's the list with supported validators:
 
 You can choose when the validation of the changes happens by changing the data form's {% typedoc_link classes:RadDataForm,member:validationMode %} property. It accepts values from the {% typedoc_link enums:DataFormValidationMode %} enumeration.
 
-```
+
+```javascript
+
 import { DataFormValidationMode } from 'nativescript-ui-dataform';
 
 export default {
@@ -127,12 +129,17 @@ export default {
     },
   }
 };
+
 ```
 
-You should have in mind that the {% typedoc_link classes:RadDataForm,member:validationMode %} property is dependent on the value of the {% typedoc_link classes:RadDataForm,member:commitMode %} property, meaning that {% typedoc_link classes:RadDataForm %} will not let you commit property changes before you validate them. In other words:
+
+You should have in mind that the {% typedoc_link classes:RadDataForm,member:validationMode %} property is dependent on the value of the {% typedoc_link classes:RadDataForm,member:commitMode %} property, meaning that {% typedoc_link classes:RadDataForm %} will not let you commit property changes before you validate them. 
+
+In other words:
 * If `commitMode` is {% typedoc_link enums:DataFormCommitMode,member:Immediate %}, validation is also immediate disregarding the value of the `validationMode` property
 * If `commitMode` is {% typedoc_link enums:DataFormCommitMode,member:OnLostFocus %}, validation is immediate, if `validationMode` is {% typedoc_link enums:DataFormValidationMode,member:Immediate %}, or {% typedoc_link enums:DataFormValidationMode,member:OnLostFocus %} otherwise
 * If `commitMode` is {% typedoc_link enums:DataFormCommitMode,member:Manual %}, validation will follow the value of `validationMode`.
+
 
 ## Validation Events
 


### PR DESCRIPTION
There are some Code and Syntax Highlighting problems on this page

I couldn't solve but this page needs some interest.

There is a **huge text dump** on the following line while using **firefox**.

import { DataFormValidationMode } from 'nativescript-ui-dataform';

> export default { template: <Page> <ActionBar> <ActionItem text="Immediate" android.position="popup" @tap="onImmediateTap"></ActionItem> <ActionItem text="OnLostFocus" android.position="popup" @tap="onOnLostFocusTap"></ActionItem> <ActionItem text="Manual" android.position="popup" @tap="onManualTap"></ActionItem> </ActionBar> <StackLayout> <RadDataForm ref="dataform" :source="person" :metadata="personMetadata" :validationMode="validationMode" commitMode="Manual"> </RadDataForm> <Button text="Validate manually" horizontalAlignment="stretch" @tap="onValidateTap()"></Button> </StackLayout> </Page> , data () { return { text: '', validationMode: DataFormValidationMode.Immediate, person: { username: '', password: '', }, personMetadata: { 'isReadOnly': false, 'propertyAnnotations': [ { 'name': 'username', 'displayName': 'Nick', 'index': 0, 'validators': [ { 'name': 'NonEmpty' }, { 'name': 'MaximumLength', 'params': { 'length': 10 } } ] }, { 'name': 'password', 'displayName': 'Password', 'index': 2, 'validators': [ { 'name': 'NonEmpty', } ] }, ] } }; }, methods: { onImmediateTap() { this.validationMode = DataFormValidationMode.Immediate; }, onOnLostFocusTap() { this.validationMode = DataFormValidationMode.OnLostFocus; }, onManualTap() { this.validationMode = DataFormValidationMode.Manual; }, onValidateTap() { this.$refs.dataform.validateAll() .then(result => { console.log(Validation result: ${result}); }); }, } };
