### PR TITLE
docs(chrome-devtools): Chrome changed devtools protocol

### DIFF
--- a/docs/tooling/debugging/chrome-devtools.md
+++ b/docs/tooling/debugging/chrome-devtools.md
@@ -39,7 +39,7 @@ For security reasons, the generated debugging agent **can't be started automatic
 
 ```Shell
 To start debugging, open the following URL in Chrome:
-chrome-devtools://devtools/bundled/inspector.html?experiments=true&ws=localhost:40000
+devtools://devtools/bundled/inspector.html?experiments=true&ws=localhost:40000
 ```
 You need to manually copy it in Google Chrome's address bar to start debugging.
 


### PR DESCRIPTION
chrome-devtools:// protocol changed to just devtools://

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] If there is an issue related with this PR, point it out here.

## What is the current state of the documentation article?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new state of the documentation article?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

