### PR TITLE
docs(Linux): Update ns-setup-linux.md

### DIFF
--- a/docs/start/ns-setup-linux.md
+++ b/docs/start/ns-setup-linux.md
@@ -68,12 +68,12 @@ Complete the following steps to set up NativeScript on your Linux development ma
         You may need to reload the `bashrc`file either by logging out and in again, or by running `source .bashrc` in the terminal from your Home directory.  
 
 5. Install the [Android SDK](http://developer.android.com/sdk/index.html).
-    1. Go to [Android Studio and SDK Downloads](https://developer.android.com/sdk/index.html#Other) and in the **SDK Tools Only** section download the package for Linux at the bottom of the page.
-    2. After the download completes, unpack the downloaded archive into a folder, such as `/usr/local/android/sdk`
-       * The archive you just extracted was the `tools` folder, so in this case it would be at: `/usr/local/android/sdk/tools`
+    1. Go to [Android Studio and SDK Downloads](https://developer.android.com/sdk/index.html#Other) and in the **Command line tools only** section download the package for Linux at the bottom of the page.
+    2. After the download completes, unpack the downloaded archive into a folder, such as `/usr/local/android/sdk/cmdline-tools`
+       * The archive you just extracted was the `tools` folder, so in this case it would be at: `/usr/local/android/sdk/cmdline-tools/tools`
     3. Set the ANDROID_HOME environment variable. Open `~/.bashrc` and add the following:
         <pre><code class="language-terminal">export ANDROID_HOME="/usr/local/android/sdk/"
-       export PATH="${PATH}:${ANDROID_HOME}tools/:${ANDROID_HOME}platform-tools/"</code></pre>
+       export PATH="${PATH}:${ANDROID_HOME}cmdline-tools/tools/:${ANDROID_HOME}platform-tools/"</code></pre>
     4. In a text file which was opened, paste in the path to your variable (at the new line).
     
     For example: `ANDROID_HOME=/usr/local/android/sdk`
@@ -82,7 +82,7 @@ Complete the following steps to set up NativeScript on your Linux development ma
 
 6. Install all packages for the Android SDK Platform 28, Android SDK Build-Tools 28.0.3 or later, Android Support Repository, Google Repository and any other SDKs that you may need. You can alternatively use the following command, which will install all required packages. In order to install SDK's go to Android Studio -> Settings -> System Settings -> Android SDK -> Mark all the Android versions you would like to support within your project (The API Level column indicates the SDK Platform).
 
-    <pre class="add-copy-button"><code class="language-terminal">sudo $ANDROID_HOME/tools/bin/sdkmanager "tools" "emulator" "platform-tools" "platforms;android-28" "build-tools;28.0.3" "extras;android;m2repository" "extras;google;m2repository"
+    <pre class="add-copy-button"><code class="language-terminal">sudo $ANDROID_HOME/cmdline-tools/tools/bin/sdkmanager "tools" "emulator" "platform-tools" "platforms;android-28" "build-tools;28.0.3" "extras;android;m2repository" "extras;google;m2repository"
     </code></pre>
 
 7. Setup Android Emulators (AVD) by following the article [here]({%slug android-emulators%})

--- a/docs/start/ns-setup-linux.md
+++ b/docs/start/ns-setup-linux.md
@@ -77,7 +77,7 @@ Complete the following steps to set up NativeScript on your Linux development ma
     4. In a text file which was opened, paste in the path to your variable (at the new line).
     
     For example: `ANDROID_HOME=/usr/local/android/sdk`
-        <blockquote><b>NOTE</b>: This is the directory that contains the <code>tools</code> (just installed) and <code>platform-tools</code> (installed by scripts in the next step) directories.</blockquote>
+        <blockquote><b>NOTE</b>: This is the directory that contains the <code>cmdlines-tools/tools</code> (just installed) and <code>platform-tools</code> (installed by scripts in the next step) directories.</blockquote>
      1. Logout from current user and login again so environment variables changes take place.
 
 6. Install all packages for the Android SDK Platform 28, Android SDK Build-Tools 28.0.3 or later, Android Support Repository, Google Repository and any other SDKs that you may need. You can alternatively use the following command, which will install all required packages. In order to install SDK's go to Android Studio -> Settings -> System Settings -> Android SDK -> Mark all the Android versions you would like to support within your project (The API Level column indicates the SDK Platform).


### PR DESCRIPTION
docs(Linux): Updated the description of folder structure for Android SDK command line tools.

1. On page https://developer.android.com/studio, the title of the section for SDK only installation, has been changed to "Command line tools only"

2. The "tools" folder now needs to be inside a new folder "cmdline-tools" (please reference: https://stackoverflow.com/questions/60440509/android-command-line-tools-sdkmanager-always-shows-warning-could-not-create-se)

Applying this change makes the installation work for me.
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] If there is an issue related with this PR, point it out here.

## What is the current state of the documentation article?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Some descriptions need to be update:
On page https://developer.android.com/studio, the title of the section for SDK only installation, has been changed to "Command line tools only"

The "tools" folder now need to be inside a new folder "cmdline-tools" (reference this stackoverflow article:
https://stackoverflow.com/questions/60440509/android-command-line-tools-sdkmanager-always-shows-warning-could-not-create-se)

## What is the new state of the documentation article?
<!-- Describe the changes. -->
Using the updatd folder structure, installation of Android SDK command line tools was successful.
Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

