### PR TITLE
docs: Wrong declarations of terms

### DIFF
--- a/docs/ui/animation.md
+++ b/docs/ui/animation.md
@@ -70,9 +70,11 @@ NativeScript lets you animate the following properties:
 
 - **opacity**
 - **backgroundColor**
-- **translateX** and **translateY**
-- **scaleX** and **scaleY**
+- **translate**
+- **scale**
 - **rotate**
+
+> To use `translate` or `scale` you must preceed with an object declaring both x and y values, for example `translate: { x: 100, y: 250 }` or `scale: { x: 1.5, y: 0 }`.
 
 In every animation, you can control the following properties:
 


### PR DESCRIPTION
There is no translateX/translateY or scaleX/scaleY. It is actually translate or scale respectively. Also explain how to use them, since they differ.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] If there is an issue related with this PR, point it out here.

## What is the current state of the documentation article?
The current documentation is using false terms.

## What is the new state of the documentation article?
I have changed it to the right terms. Using the old ones would throw an error.

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

