### PR TITLE
fix: grammar correction

### DIFF
--- a/docs/core-concepts/application-architecture.md
+++ b/docs/core-concepts/application-architecture.md
@@ -79,7 +79,7 @@ These modules are used as the root for UI containers. Currently, there are only 
 * The app container - it is only one. You set its root module by passing it to the `application.run()` method.
 * Modal view containers - You can have a lot of these. You set a modal view's root module by passing it to the `showModal()` method of any UI component.
 
-A root module can have only one component at the root of its content. You can put virtually any UI component as a root, but the most commonly used components are the one that can have children - the layouts, `TabView`, `SideDrawer` or `Frame`. The `Frame` component can't have children, but it can display and navigate between page modules.
+A root module can have only one component at the root of its content. You can put virtually any UI component as a root, but the most commonly used components are the ones that can have children - the layouts, `TabView`, `SideDrawer` or `Frame`. The `Frame` component can't have children, but it can display and navigate between page modules.
 
 Note that the root module will be loaded regardless of navigations until its UI container disappears. This basically means that the app root module will always be loaded. A modal view root module will be unloaded when the modal view is closed.
 


### PR DESCRIPTION
docs (application-architecture): change noun to plural

Change noun used on line 82 to the plural form. Change the "one" in the text, "but the most commonly used components are the one that" to "ones"

Closes #1909

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] If there is an issue related with this PR, point it out here.

## What is the current state of the documentation article?
#1909 

## What is the new state of the documentation article?
Changed the "one" in this statement "but the most commonly used components are the one that" to "ones"

Fixes/Implements/Closes #[1909].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

