### PR TITLE
docs: Update e2e testing overview.md

### DIFF
--- a/docs/tooling/testing/end-to-end-testing/overview.md
+++ b/docs/tooling/testing/end-to-end-testing/overview.md
@@ -37,7 +37,7 @@ For the plugin to work correctly you need to have:
 
 * Install Appium globally:
 ```shell
-$ npm install -g appium
+$ npm install -g appium@1.18.1
 ```
 
 * iOS Dependencies


### PR DESCRIPTION
doc(e2e-testing-overview): add global appium ver

The current version of `appium` on npm is 1.19.0, which is incompatible with `nativescript-dev-appium@6.1.3` and lower (more specifically if fails to verify the signature of `appium-uiautomator2-server-v4.15.0.apk`). Appending the version to the global install prevents this incompatibility error.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] If there is an issue related with this PR, point it out here.

## What is the current state of the documentation article?
Current `appium` version on npm is incompatible with appium-uiautomator2-server-v4.15.0.apk

## What is the new state of the documentation article?
Instructs the user to install `appium@1.18.1` rather than `appium` latest

Fixes/Implements/Closes #[Issue Number].


