### PR TITLE
fix(docs): remove cask from brew commands

### DIFF
--- a/docs/start/ns-setup-os-x.md
+++ b/docs/start/ns-setup-os-x.md
@@ -102,7 +102,7 @@ Complete the following steps to setup NativeScript on your macOS development mac
     <pre class="add-copy-button"><code class="language-terminal">brew tap AdoptOpenJDK/openjdk
     </code></pre>
 
-    <pre class="add-copy-button"><code class="language-terminal">brew cask install adoptopenjdk8
+    <pre class="add-copy-button"><code class="language-terminal">brew install adoptopenjdk8
     </code></pre>
     
     2. Set the JAVA_HOME system environment variable.
@@ -113,7 +113,7 @@ Complete the following steps to setup NativeScript on your macOS development mac
     3. Install the [Android SDK](http://developer.android.com/sdk/index.html).
         1. In the terminal, run the following command:
 
-            <pre class="add-copy-button"><code class="language-terminal">brew cask install android-sdk
+            <pre class="add-copy-button"><code class="language-terminal">brew install android-sdk
             </code></pre>
 
         2. Next, run the following command to set the ANDROID_HOME system environment variable:

--- a/docs/start/ns-setup-os-x.md
+++ b/docs/start/ns-setup-os-x.md
@@ -102,7 +102,7 @@ Complete the following steps to setup NativeScript on your macOS development mac
     <pre class="add-copy-button"><code class="language-terminal">brew tap AdoptOpenJDK/openjdk
     </code></pre>
 
-    <pre class="add-copy-button"><code class="language-terminal">brew install adoptopenjdk8
+    <pre class="add-copy-button"><code class="language-terminal">brew install --cask adoptopenjdk8
     </code></pre>
     
     2. Set the JAVA_HOME system environment variable.
@@ -113,7 +113,7 @@ Complete the following steps to setup NativeScript on your macOS development mac
     3. Install the [Android SDK](http://developer.android.com/sdk/index.html).
         1. In the terminal, run the following command:
 
-            <pre class="add-copy-button"><code class="language-terminal">brew install android-sdk
+            <pre class="add-copy-button"><code class="language-terminal">brew install --cask android-sdk
             </code></pre>
 
         2. Next, run the following command to set the ANDROID_HOME system environment variable:


### PR DESCRIPTION
It is no longer required to install cask packages with `brew cask`, since it has been integrated within brew itself in version 2.5.

See the release notes for more information
https://brew.sh/2020/09/08/homebrew-2.5.0/

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] If there is an issue related with this PR, point it out here.

## What is the current state of the documentation article?
Many brew cask commands have been integrated with brew. The commands that use cask in the documentation don't work anymore.

## What is the new state of the documentation article?
The two commands that make use of cask have been updated, so that they work again.

