### PR TITLE
Fix: the Grammer correction

### DIFF
--- a/config
+++ b/config
@@ -1,5 +1,5 @@
 #Default GitHub
 Host github.com
-  HostName github.com
-  User git
-  IdentityFile ~/.ssh/id_rsa_COMPANY
+   HostName github.com
+   User git
+   IdentityFile ~/.ssh/id_rsa_COMPANY

--- a/docs/core-concepts/application-architecture.md
+++ b/docs/core-concepts/application-architecture.md
@@ -78,7 +78,7 @@ These modules are used as the root for UI containers. Currently, there are only 
 * The app container - it is only one. You set its root module by passing it to the `Application.run()` method.
 * Modal view containers - You can have a lot of these. You set a modal view's root module by passing it to the `showModal()` method of any UI component.
 
-A root module can have only one component at the root of its content. You can put virtually any UI component as a root, but the most commonly used components are the one that can have children - the layouts, `TabView`, `SideDrawer` or `Frame`. The `Frame` component can't have children, but it can display and navigate between page modules.
+A root module can have only one component at the root of its content. You can put virtually any UI component as a root, but the most commonly used components are the ones that can have children - the layouts, `TabView`, `SideDrawer` or `Frame`. The `Frame` component can't have children, but it can display and navigate between page modules.
 
 Note that the root module will be loaded regardless of navigations until its UI container disappears. This basically means that the app root module will always be loaded. A modal view root module will be unloaded when the modal view is closed.
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->docs (application-architecture): change noun to plural

Change noun used on line 82 to the plural form. Change the "one" in the text, "but the most commonly used components are the one that" to "ones"

Closes #1909

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ x] If there is an issue related with this PR, point it out here.

## What is the current state of the documentation article?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new state of the documentation article?
<!-- Describe the changes. -->
#1909
Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
Changed the "one" in this statement "but the most commonly used components are the one that" to "ones"

Fixes/Implements/Closes #[1909].