### PR TITLE
Add userName and password hint options for login

### DIFF
--- a/docs/ui/dialogs.md
+++ b/docs/ui/dialogs.md
@@ -221,7 +221,9 @@ Dialogs.login({
     cancelButtonText: "Cancel button text",
     neutralButtonText: "Neutral button text",
     userName: "User name label text",
-    password: "Password label text"
+    userNameHint: "Enter username",
+    password: "Password label text",
+    passwordHint: "Enter password"
 }).then(r => {
     console.log("Dialog result: " + r.result + ", user: " + r.userName + ", pwd: " + r.password);
 });


### PR DESCRIPTION
Add userName and password hint options to the Dialogs.login example.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] If there is an issue related with this PR, point it out here.

## What is the current state of the documentation article?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The current doc does not mention or demonstrate the available input placeholders via the `userNameHint` and `passwordHint` options.

## What is the new state of the documentation article?
<!-- Describe the changes. -->
I added both options to the existing example

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
n/a
